### PR TITLE
Add to gitignore self-signed cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ npm-debug.log
 
 # Ignore .vscode dir
 /.vscode
+
+# Ignore self-signed cert
+priv/cert/


### PR DESCRIPTION
This adds to gitignore the self signed cert generated by `mix phx.gen.cert`