### PR TITLE
set things up so we can replace landing page

### DIFF
--- a/lib/banchan_web/components/layout.ex
+++ b/lib/banchan_web/components/layout.ex
@@ -65,7 +65,12 @@ defmodule BanchanWeb.Components.Layout do
           </div>
         </footer>
       </div>
-      <div class="drawer-side">
+
+      {!-- # TODO: remove this basic auth check on launch --}
+      <div
+        :if={@current_user || is_nil(Application.get_env(:banchan, :basic_auth))}
+        class="drawer-side"
+      >
         <label for="drawer-toggle" class="drawer-overlay" />
         <aside class="bg-base-200 w-48 shadow">
           <ul tabindex="0" class="menu flex flex-col p-2 gap-2">

--- a/lib/banchan_web/live/beta_live/signup.ex
+++ b/lib/banchan_web/live/beta_live/signup.ex
@@ -102,16 +102,18 @@ defmodule BanchanWeb.BetaLive.Signup do
                 <span class="text-primary whitespace-nowrap">All in one spot</span>.
               </div>
             </div>
-            <div class="blur-edges themed dark">
+            <div class="rounded-lg shadow-xl themed dark shadow-black outline outline-primary outline-3">
               <img
                 alt="Screenshot of an ongoing commission. The title is 'Please draw my OC'. There are various elements of interest on the page, such as a status, a summary of what is being paid for, and some art on the page."
                 src={Routes.static_path(Endpoint, "/images/banchan-comm-dark.png")}
+                class="rounded-lg"
               />
             </div>
-            <div class="blur-edges themed light">
+            <div class="rounded-lg shadow-xl themed light shadow-secondary outline outline-primary outline-3">
               <img
                 alt="Screenshot of an ongoing commission. The title is 'Please draw my OC'. There are various elements of interest on the page, such as a status, a summary of what is being paid for, and some art on the page."
                 src={Routes.static_path(Endpoint, "/images/banchan-comm-light.png")}
+                class="rounded-lg"
               />
             </div>
           </div>
@@ -145,16 +147,18 @@ defmodule BanchanWeb.BetaLive.Signup do
               </div>
             </div>
             <div class="md:order-1">
-              <div class="blur-edges themed dark">
+              <div class="rounded-lg shadow-xl themed dark shadow-black outline outline-primary outline-3">
                 <img
                   alt="Screenshot showing the Banchan invoicing feature. There is a message saying that the commission is complete, and a message box that says Payment Succeeded, $120, plug a Release Now button. There is artwork attached to the message."
                   src={Routes.static_path(Endpoint, "/images/banchan-invoice-dark.png")}
+                  class="rounded-lg"
                 />
               </div>
-              <div class="blur-edges themed light">
+              <div class="rounded-lg shadow-xl themed light shadow-secondary outline outline-primary outline-3">
                 <img
                   alt="Screenshot showing the Banchan invoicing feature. There is a message saying that the commission is complete, and a message box that says Payment Succeeded, $120, plug a Release Now button. There is artwork attached to the message."
                   src={Routes.static_path(Endpoint, "/images/banchan-invoice-light.png")}
+                  class="rounded-lg"
                 />
               </div>
             </div>
@@ -179,16 +183,18 @@ defmodule BanchanWeb.BetaLive.Signup do
               </div>
             </div>
             <div>
-              <div class="blur-edges themed dark">
+              <div class="rounded-lg shadow-xl themed dark shadow-black outline outline-primary outline-3">
                 <img
                   alt="Screenshot of an example Banchan shop, including a beautiful header graphic, the name of the studio, and three separate offerings: Flat Full Color, Full Color Shaded, and Sketch. They each have 3 slots available."
                   src={Routes.static_path(Endpoint, "/images/banchan-shop-dark.png")}
+                  class="rounded-lg"
                 />
               </div>
-              <div class="blur-edges themed light">
+              <div class="rounded-lg shadow-xl themed light shadow-secondary outline outline-primary outline-3">
                 <img
                   alt="Screenshot of an example Banchan shop, including a beautiful header graphic, the name of the studio, and three separate offerings: Flat Full Color, Full Color Shaded, and Sketch. They each have 3 slots available."
                   src={Routes.static_path(Endpoint, "/images/banchan-shop-light.png")}
+                  class="rounded-lg"
                 />
               </div>
             </div>
@@ -198,7 +204,7 @@ defmodule BanchanWeb.BetaLive.Signup do
       <div id="bottom-cta" class="px-2 md:px-4">
         <div class="hero py-8">
           <div class="hero-content flex flex-col items-center gap-10">
-            <div class="card shadow-2xl bg-base-200">
+            <div class="card shadow-xl bg-base-200 shadow-secondary">
               <div class="card-body flex flex-col gap-4 p-4 items-center max-w-4xl">
                 <div class="text-5xl font-bold">
                   Sign Up for Updates and

--- a/lib/banchan_web/live/home_live/index.ex
+++ b/lib/banchan_web/live/home_live/index.ex
@@ -79,97 +79,116 @@ defmodule BanchanWeb.HomeLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
-      <:hero>
-        <div id="carousel-handler" class="flex-grow">
-          <Carousel
-            id="studio-carousel"
-            label="Featured Studios"
-            class="rounded-b-xl aspect-header-image h-full w-full"
-          >
-            {#for studio <- @featured_studios.entries}
-              <Carousel.Slide class="carousel-item w-full aspect-header-image">
-                <LiveRedirect
-                  class="w-full h-full aspect-header-image relative"
-                  to={Routes.studio_shop_path(Endpoint, :show, studio.handle)}
-                >
-                  <img
-                    class="object-cover aspect-header-image w-full"
-                    src={Routes.public_image_path(Endpoint, :image, :studio_header_img, studio.header_img_id)}
-                  />
-                  <div class="absolute top-2 left-2 md:top-6 md:left-6 text-3xl sm:text-3xl md:text-6xl font-bold text-white text-shadow-lg shadow-black">
-                    {studio.name}
-                  </div>
-                </LiveRedirect>
-              </Carousel.Slide>
+    {#if @current_user || is_nil(Application.get_env(:banchan, :basic_auth))}
+      <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+        <:hero>
+          <div id="carousel-handler" class="flex-grow">
+            <Carousel
+              id="studio-carousel"
+              label="Featured Studios"
+              class="rounded-b-xl aspect-header-image h-full w-full"
+            >
+              {#for studio <- @featured_studios.entries}
+                <Carousel.Slide class="carousel-item w-full aspect-header-image">
+                  <LiveRedirect
+                    class="w-full h-full aspect-header-image relative"
+                    to={Routes.studio_shop_path(Endpoint, :show, studio.handle)}
+                  >
+                    <img
+                      class="object-cover aspect-header-image w-full"
+                      src={Routes.public_image_path(Endpoint, :image, :studio_header_img, studio.header_img_id)}
+                    />
+                    <div class="absolute top-2 left-2 md:top-6 md:left-6 text-3xl sm:text-3xl md:text-6xl font-bold text-white text-shadow-lg shadow-black">
+                      {studio.name}
+                    </div>
+                  </LiveRedirect>
+                </Carousel.Slide>
+              {/for}
+            </Carousel>
+          </div>
+        </:hero>
+        <div class="flex flex-col gap-2">
+          <Form for={:search} submit="search" class="w-full">
+            <div class="flex flex-row flex-nowrap w-full md:w-content max-w-xl mx-auto">
+              <Field name={:query} class="w-full">
+                <TextInput
+                  name={:query}
+                  class="w-full input input-bordered"
+                  opts={placeholder: "Search for offerings..."}
+                />
+              </Field>
+              <Submit class="btn btn-round">
+                <i class="fas fa-search" />
+              </Submit>
+            </div>
+          </Form>
+          <div class="flex flex-row flex-wrap gap-2 mx-auto justify-center">
+            {#for cat <- @categories}
+              <Tag tag={cat} />
             {/for}
-          </Carousel>
-        </div>
-      </:hero>
-      <div class="flex flex-col gap-2">
-        <Form for={:search} submit="search" class="w-full">
-          <div class="flex flex-row flex-nowrap w-full md:w-content max-w-xl mx-auto">
-            <Field name={:query} class="w-full">
-              <TextInput
-                name={:query}
-                class="w-full input input-bordered"
-                opts={placeholder: "Search for offerings..."}
-              />
-            </Field>
-            <Submit class="btn btn-round">
-              <i class="fas fa-search" />
-            </Submit>
           </div>
-        </Form>
-        <div class="flex flex-row flex-wrap gap-2 mx-auto justify-center">
-          {#for cat <- @categories}
-            <Tag tag={cat} />
-          {/for}
-        </div>
-        <div class="homepage-offerings">
-          <div class="pt-6 px-2 flex flex-row items-end">
-            <div class="text-xl grow">
-              Selected Offerings
+          <div class="homepage-offerings">
+            <div class="pt-6 px-2 flex flex-row items-end">
+              <div class="text-xl grow">
+                Selected Offerings
+              </div>
+              <div class="text-md">
+                <LiveRedirect
+                  class="hover:link text-primary"
+                  to={Routes.discover_index_path(Endpoint, :index, "offerings")}
+                >Discover More</LiveRedirect>
+              </div>
             </div>
-            <div class="text-md">
-              <LiveRedirect
-                class="hover:link text-primary"
-                to={Routes.discover_index_path(Endpoint, :index, "offerings")}
-              >Discover More</LiveRedirect>
+            <div class="divider" />
+            <div class="sm:px-2 flex flex-col gap-4">
+              <div class="grid grid-cols-2 sm:gap-2 md:grid-cols-4 auto-rows-fr">
+                {#for {offering, idx} <- Enum.with_index(@offerings.entries)}
+                  <OfferingCard id={"offering-#{idx}"} current_user={@current_user} offering={offering} />
+                {/for}
+              </div>
             </div>
           </div>
-          <div class="divider" />
-          <div class="sm:px-2 flex flex-col gap-4">
-            <div class="grid grid-cols-2 sm:gap-2 md:grid-cols-4 auto-rows-fr">
-              {#for {offering, idx} <- Enum.with_index(@offerings.entries)}
-                <OfferingCard id={"offering-#{idx}"} current_user={@current_user} offering={offering} />
-              {/for}
+          <div class="featured-studios pt-10">
+            <div class="px-2 flex flex-row items-end">
+              <div class="text-xl grow">
+                Selected Studios
+              </div>
+              <div class="text-md">
+                <LiveRedirect
+                  class="hover:link text-primary"
+                  to={Routes.discover_index_path(Endpoint, :index, "studios")}
+                >Discover More</LiveRedirect>
+              </div>
             </div>
-          </div>
-        </div>
-        <div class="featured-studios pt-10">
-          <div class="px-2 flex flex-row items-end">
-            <div class="text-xl grow">
-              Selected Studios
-            </div>
-            <div class="text-md">
-              <LiveRedirect
-                class="hover:link text-primary"
-                to={Routes.discover_index_path(Endpoint, :index, "studios")}
-              >Discover More</LiveRedirect>
-            </div>
-          </div>
-          <div class="divider" />
-          <div class="sm:px-2 flex flex-col gap-4">
-            <div class="studio-list grid grid-cols-1 sm:gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 auto-rows-fr">
-              {#for studio <- @studios.entries}
-                <StudioCard studio={studio} />
-              {/for}
+            <div class="divider" />
+            <div class="sm:px-2 flex flex-col gap-4">
+              <div class="studio-list grid grid-cols-1 sm:gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 auto-rows-fr">
+                {#for studio <- @studios.entries}
+                  <StudioCard studio={studio} />
+                {/for}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Layout>
+      </Layout>
+    {#else}
+      <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+        <div id="above-fold" class="md:px-4">
+          <div class="min-h-screen hero">
+            <div class="hero-content flex flex-col md:flex-row">
+              <div class="flex flex-col gap-4 items-center max-w-2xl">
+                <div class="text-5xl font-bold">
+                  Coming <span class="text-primary font-bold">Soon</span>
+                </div>
+                <div class="text-lg">
+                  <LiveRedirect to={Routes.beta_signup_path(Endpoint, :new)}>Learn More →</LiveRedirect>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Layout>
+    {/if}
     """
   end
 end

--- a/lib/banchan_web/live/static_live/contact_live.ex
+++ b/lib/banchan_web/live/static_live/contact_live.ex
@@ -20,7 +20,7 @@ defmodule BanchanWeb.StaticLive.Contact do
       <#Markdown class="prose">
         # Contact Us
 
-        TKTK
+        Feel free to email us at [support@banchan.art](mailto:support@banchan.art).
       </#Markdown>
     </Layout>
     """

--- a/lib/banchan_web/live/static_live/refunds_and_disputes_live.ex
+++ b/lib/banchan_web/live/static_live/refunds_and_disputes_live.ex
@@ -20,7 +20,7 @@ defmodule BanchanWeb.StaticLive.RefundsAndDisputes do
       <#Markdown class="prose">
         # Refunds and Disputes Policy
 
-        TKTK idk we just take care of it for you? Don't try and scam us?
+        Check back in after launch. We're still working on finalizing this policy.
       </#Markdown>
     </Layout>
     """


### PR DESCRIPTION
This makes it so we can just straight-up swap out the current landing page for the actual, real Banchan app and beta signups get handled by the app itself, but the non-public part of the app is hidden behind a basic auth wall.