### PR TITLE
Move some stuff to context

### DIFF
--- a/lib/banchan_web/components/flash.ex
+++ b/lib/banchan_web/components/flash.ex
@@ -4,12 +4,12 @@ defmodule BanchanWeb.Components.Flash do
   """
   use BanchanWeb, :component
 
-  prop flash, :any, required: true
+  prop flashes, :any, required: true
 
   def render(assigns) do
     ~F"""
     <div class="flash-container">
-      {#if live_flash(@flash, :success)}
+      {#if live_flash(@flashes, :success)}
         <div
           class="alert alert-success shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -18,12 +18,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-check-circle" />
-            <span>{live_flash(@flash, :success)}</span>
+            <span>{live_flash(@flashes, :success)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flash, :info)}
+      {#if live_flash(@flashes, :info)}
         <div
           class="alert alert-info shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -32,12 +32,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-info-circle" />
-            <span>{live_flash(@flash, :info)}</span>
+            <span>{live_flash(@flashes, :info)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flash, :warning)}
+      {#if live_flash(@flashes, :warning)}
         <div
           class="alert alert-warning shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -46,12 +46,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-exclamation-triangle" />
-            <span>{live_flash(@flash, :warning)}</span>
+            <span>{live_flash(@flashes, :warning)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flash, :error)}
+      {#if live_flash(@flashes, :error)}
         <div
           class="alert alert-error shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -60,7 +60,7 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-exclamation-circle" />
-            <span>{live_flash(@flash, :error)}</span>
+            <span>{live_flash(@flashes, :error)}</span>
           </div>
         </div>
       {/if}

--- a/lib/banchan_web/components/flash.ex
+++ b/lib/banchan_web/components/flash.ex
@@ -4,7 +4,7 @@ defmodule BanchanWeb.Components.Flash do
   """
   use BanchanWeb, :component
 
-  prop flash, :any, from_context: :flash
+  prop flash, :any, required: true
 
   def render(assigns) do
     ~F"""

--- a/lib/banchan_web/components/flash.ex
+++ b/lib/banchan_web/components/flash.ex
@@ -4,12 +4,12 @@ defmodule BanchanWeb.Components.Flash do
   """
   use BanchanWeb, :component
 
-  prop flashes, :any
+  prop flash, :any, from_context: :flash
 
   def render(assigns) do
     ~F"""
     <div class="flash-container">
-      {#if live_flash(@flashes, :success)}
+      {#if live_flash(@flash, :success)}
         <div
           class="alert alert-success shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -18,12 +18,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-check-circle" />
-            <span>{live_flash(@flashes, :success)}</span>
+            <span>{live_flash(@flash, :success)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flashes, :info)}
+      {#if live_flash(@flash, :info)}
         <div
           class="alert alert-info shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -32,12 +32,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-info-circle" />
-            <span>{live_flash(@flashes, :info)}</span>
+            <span>{live_flash(@flash, :info)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flashes, :warning)}
+      {#if live_flash(@flash, :warning)}
         <div
           class="alert alert-warning shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -46,12 +46,12 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-exclamation-triangle" />
-            <span>{live_flash(@flashes, :warning)}</span>
+            <span>{live_flash(@flash, :warning)}</span>
           </div>
         </div>
       {/if}
 
-      {#if live_flash(@flashes, :error)}
+      {#if live_flash(@flash, :error)}
         <div
           class="alert alert-error shadow-lg p-2 hover:cursor-pointer"
           role="alert"
@@ -60,7 +60,7 @@ defmodule BanchanWeb.Components.Flash do
         >
           <div>
             <i class="fas fa-exclamation-circle" />
-            <span>{live_flash(@flashes, :error)}</span>
+            <span>{live_flash(@flash, :error)}</span>
           </div>
         </div>
       {/if}

--- a/lib/banchan_web/components/layout.ex
+++ b/lib/banchan_web/components/layout.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.Components.Layout do
   alias BanchanWeb.Components.{Flash, Nav}
 
   prop current_user, :any, from_context: :current_user
-  prop flash, :any, required: true
+  prop flashes, :any, required: true
   prop padding, :integer, default: 4
 
   slot hero
@@ -36,7 +36,7 @@ defmodule BanchanWeb.Components.Layout do
               ⚠️You need to verify your email address before you can do certain things on the site, such as submit new commissions. Please check your email or <LiveRedirect class="link" to={Routes.confirmation_path(Endpoint, :show)}>click here to resend your confirmation</LiveRedirect>.⚠️
             </div>
           </div>
-          <Flash flash={@flash}/>
+          <Flash flashes={@flashes} />
           <#slot />
         </section>
         <footer class="footer p-10 shadow-sm">

--- a/lib/banchan_web/components/layout.ex
+++ b/lib/banchan_web/components/layout.ex
@@ -12,7 +12,8 @@ defmodule BanchanWeb.Components.Layout do
 
   alias BanchanWeb.Components.{Flash, Nav}
 
-  prop current_user, :any
+  prop current_user, :any, from_context: :current_user
+  prop flash, :any, required: true
   prop padding, :integer, default: 4
 
   slot hero
@@ -35,7 +36,7 @@ defmodule BanchanWeb.Components.Layout do
               ⚠️You need to verify your email address before you can do certain things on the site, such as submit new commissions. Please check your email or <LiveRedirect class="link" to={Routes.confirmation_path(Endpoint, :show)}>click here to resend your confirmation</LiveRedirect>.⚠️
             </div>
           </div>
-          <Flash />
+          <Flash flash={@flash}/>
           <#slot />
         </section>
         <footer class="footer p-10 shadow-sm">

--- a/lib/banchan_web/components/layout.ex
+++ b/lib/banchan_web/components/layout.ex
@@ -13,8 +13,6 @@ defmodule BanchanWeb.Components.Layout do
   alias BanchanWeb.Components.{Flash, Nav}
 
   prop current_user, :any
-  prop flashes, :string
-  prop uri, :string, required: true
   prop padding, :integer, default: 4
 
   slot hero
@@ -26,7 +24,7 @@ defmodule BanchanWeb.Components.Layout do
       <input type="checkbox" id="drawer-toggle" class="drawer-toggle">
       <div class="drawer-content h-screen flex flex-col flex-grow">
         <div class="top-0 z-50 sticky shadow-sm">
-          <Nav uri={@uri} current_user={@current_user} />
+          <Nav />
         </div>
         {#if slot_assigned?(:hero)}
           <#slot {@hero} />
@@ -37,7 +35,7 @@ defmodule BanchanWeb.Components.Layout do
               ⚠️You need to verify your email address before you can do certain things on the site, such as submit new commissions. Please check your email or <LiveRedirect class="link" to={Routes.confirmation_path(Endpoint, :show)}>click here to resend your confirmation</LiveRedirect>.⚠️
             </div>
           </div>
-          <Flash flashes={@flashes} />
+          <Flash />
           <#slot />
         </section>
         <footer class="footer p-10 shadow-sm">

--- a/lib/banchan_web/components/nav.ex
+++ b/lib/banchan_web/components/nav.ex
@@ -9,8 +9,7 @@ defmodule BanchanWeb.Components.Nav do
   alias BanchanWeb.Components.Notifications
   alias BanchanWeb.Endpoint
 
-  prop current_user, :any
-  prop uri, :string, required: true
+  prop current_user, :any, from_context: :current_user
 
   def render(assigns) do
     ~F"""
@@ -53,7 +52,7 @@ defmodule BanchanWeb.Components.Nav do
 
       {#if @current_user}
         <div class="flex-none">
-          <Notifications id="notifications" uri={@uri} current_user={@current_user} />
+          <Notifications id="notifications" />
         </div>
       {/if}
     </nav>

--- a/lib/banchan_web/components/notifications.ex
+++ b/lib/banchan_web/components/notifications.ex
@@ -9,8 +9,8 @@ defmodule BanchanWeb.Components.Notifications do
   alias Banchan.Notifications
   alias Banchan.Notifications.UserNotification
 
-  prop current_user, :any, required: true
-  prop uri, :string, required: true
+  prop current_user, :any, from_context: :current_user
+  prop uri, :string, from_context: :uri
 
   data loaded, :boolean, default: false
   data open, :boolean, default: false

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -22,7 +22,7 @@ defmodule BanchanWeb.AccountDisabledLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flash} padding={0}>
       <div class="w-full h-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <div class="text-xl">

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -21,13 +21,14 @@ defmodule BanchanWeb.AccountDisabledLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+    <Layout padding={0}>
       <div class="w-full h-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <div class="text-xl">

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -20,15 +20,9 @@ defmodule BanchanWeb.AccountDisabledLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full h-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <div class="text-xl">

--- a/lib/banchan_web/live/auth_live/account_disabled_live.ex
+++ b/lib/banchan_web/live/auth_live/account_disabled_live.ex
@@ -21,7 +21,7 @@ defmodule BanchanWeb.AccountDisabledLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/components/auth_layout.ex
+++ b/lib/banchan_web/live/auth_live/components/auth_layout.ex
@@ -6,11 +6,13 @@ defmodule BanchanWeb.AuthLive.Components.AuthLayout do
 
   alias BanchanWeb.Components.Layout
 
+  prop flash, :any, required: true
+
   slot default
 
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <#slot />

--- a/lib/banchan_web/live/auth_live/components/auth_layout.ex
+++ b/lib/banchan_web/live/auth_live/components/auth_layout.ex
@@ -6,13 +6,13 @@ defmodule BanchanWeb.AuthLive.Components.AuthLayout do
 
   alias BanchanWeb.Components.Layout
 
-  prop flash, :any, required: true
+  prop flashes, :any, required: true
 
   slot default
 
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flashes} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <#slot />

--- a/lib/banchan_web/live/auth_live/components/auth_layout.ex
+++ b/lib/banchan_web/live/auth_live/components/auth_layout.ex
@@ -6,15 +6,11 @@ defmodule BanchanWeb.AuthLive.Components.AuthLayout do
 
   alias BanchanWeb.Components.Layout
 
-  prop uri, :string, required: true
-  prop current_user, :any, required: true
-  prop flashes, :any, required: true
-
   slot default
 
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flashes}>
+    <Layout padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <#slot />

--- a/lib/banchan_web/live/auth_live/confirmation_live.ex
+++ b/lib/banchan_web/live/auth_live/confirmation_live.ex
@@ -15,7 +15,7 @@ defmodule BanchanWeb.ConfirmationLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl mx-auto">Resend Confirmation</h1>
         <p>Email confirmation will be sent again to this address.</p>

--- a/lib/banchan_web/live/auth_live/confirmation_live.ex
+++ b/lib/banchan_web/live/auth_live/confirmation_live.ex
@@ -14,7 +14,7 @@ defmodule BanchanWeb.ConfirmationLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/confirmation_live.ex
+++ b/lib/banchan_web/live/auth_live/confirmation_live.ex
@@ -13,15 +13,9 @@ defmodule BanchanWeb.ConfirmationLive do
   alias BanchanWeb.Endpoint
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl mx-auto">Resend Confirmation</h1>
         <p>Email confirmation will be sent again to this address.</p>

--- a/lib/banchan_web/live/auth_live/confirmation_live.ex
+++ b/lib/banchan_web/live/auth_live/confirmation_live.ex
@@ -14,13 +14,14 @@ defmodule BanchanWeb.ConfirmationLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl mx-auto">Resend Confirmation</h1>
         <p>Email confirmation will be sent again to this address.</p>

--- a/lib/banchan_web/live/auth_live/forgot_password_live.ex
+++ b/lib/banchan_web/live/auth_live/forgot_password_live.ex
@@ -15,7 +15,7 @@ defmodule BanchanWeb.ForgotPasswordLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl">Forgot your password?</h1>
         <p>If you have an account, instructions for password reset will be sent to it.</p>

--- a/lib/banchan_web/live/auth_live/forgot_password_live.ex
+++ b/lib/banchan_web/live/auth_live/forgot_password_live.ex
@@ -14,7 +14,7 @@ defmodule BanchanWeb.ForgotPasswordLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/forgot_password_live.ex
+++ b/lib/banchan_web/live/auth_live/forgot_password_live.ex
@@ -13,15 +13,9 @@ defmodule BanchanWeb.ForgotPasswordLive do
   alias BanchanWeb.Endpoint
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl">Forgot your password?</h1>
         <p>If you have an account, instructions for password reset will be sent to it.</p>

--- a/lib/banchan_web/live/auth_live/forgot_password_live.ex
+++ b/lib/banchan_web/live/auth_live/forgot_password_live.ex
@@ -14,13 +14,14 @@ defmodule BanchanWeb.ForgotPasswordLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <Form class="flex flex-col gap-4" for={:user} submit="submit">
         <h1 class="text-2xl">Forgot your password?</h1>
         <p>If you have an account, instructions for password reset will be sent to it.</p>

--- a/lib/banchan_web/live/auth_live/login_live.ex
+++ b/lib/banchan_web/live/auth_live/login_live.ex
@@ -21,15 +21,9 @@ defmodule BanchanWeb.LoginLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/login_live.ex
+++ b/lib/banchan_web/live/auth_live/login_live.ex
@@ -22,13 +22,14 @@ defmodule BanchanWeb.LoginLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/login_live.ex
+++ b/lib/banchan_web/live/auth_live/login_live.ex
@@ -23,7 +23,7 @@ defmodule BanchanWeb.LoginLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/login_live.ex
+++ b/lib/banchan_web/live/auth_live/login_live.ex
@@ -22,7 +22,7 @@ defmodule BanchanWeb.LoginLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/reactivate_live.ex
+++ b/lib/banchan_web/live/auth_live/reactivate_live.ex
@@ -37,7 +37,7 @@ defmodule BanchanWeb.ReactivateLive do
       end
 
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <h1 class="text-2xl mx-auto">Reactivate Your Account</h1>
       <p>Your account is currently deactivated and will be fully deleted in {days}.</p>
       <Button click="reactivate" class="w-full" label="Reactivate" />

--- a/lib/banchan_web/live/auth_live/reactivate_live.ex
+++ b/lib/banchan_web/live/auth_live/reactivate_live.ex
@@ -11,6 +11,7 @@ defmodule BanchanWeb.ReactivateLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -42,7 +43,7 @@ defmodule BanchanWeb.ReactivateLive do
       end
 
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <h1 class="text-2xl mx-auto">Reactivate Your Account</h1>
       <p>Your account is currently deactivated and will be fully deleted in {days}.</p>
       <Button click="reactivate" class="w-full" label="Reactivate" />

--- a/lib/banchan_web/live/auth_live/reactivate_live.ex
+++ b/lib/banchan_web/live/auth_live/reactivate_live.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.ReactivateLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/reactivate_live.ex
+++ b/lib/banchan_web/live/auth_live/reactivate_live.ex
@@ -10,12 +10,6 @@ defmodule BanchanWeb.ReactivateLive do
   alias BanchanWeb.Components.Button
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("reactivate", _, socket) do
     case Accounts.reactivate_user(socket.assigns.current_user, socket.assigns.current_user) do
       {:ok, _} ->
@@ -43,7 +37,7 @@ defmodule BanchanWeb.ReactivateLive do
       end
 
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <h1 class="text-2xl mx-auto">Reactivate Your Account</h1>
       <p>Your account is currently deactivated and will be fully deleted in {days}.</p>
       <Button click="reactivate" class="w-full" label="Reactivate" />

--- a/lib/banchan_web/live/auth_live/register_live.ex
+++ b/lib/banchan_web/live/auth_live/register_live.ex
@@ -28,12 +28,6 @@ defmodule BanchanWeb.RegisterLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("change", val, socket) do
     changeset =
       %User{}
@@ -56,7 +50,7 @@ defmodule BanchanWeb.RegisterLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/register_live.ex
+++ b/lib/banchan_web/live/auth_live/register_live.ex
@@ -29,7 +29,7 @@ defmodule BanchanWeb.RegisterLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/register_live.ex
+++ b/lib/banchan_web/live/auth_live/register_live.ex
@@ -29,6 +29,7 @@ defmodule BanchanWeb.RegisterLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -55,7 +56,7 @@ defmodule BanchanWeb.RegisterLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/register_live.ex
+++ b/lib/banchan_web/live/auth_live/register_live.ex
@@ -50,7 +50,7 @@ defmodule BanchanWeb.RegisterLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <Form
         class="flex flex-col gap-4"
         for={@changeset}

--- a/lib/banchan_web/live/auth_live/reset_password_live.ex
+++ b/lib/banchan_web/live/auth_live/reset_password_live.ex
@@ -29,13 +29,14 @@ defmodule BanchanWeb.ResetPasswordLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <Form class="flex flex-col gap-4" for={@changeset} change="change" submit="submit">
         <h1 class="text-2xl">Reset Password</h1>
         <TextInput

--- a/lib/banchan_web/live/auth_live/reset_password_live.ex
+++ b/lib/banchan_web/live/auth_live/reset_password_live.ex
@@ -30,7 +30,7 @@ defmodule BanchanWeb.ResetPasswordLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <Form class="flex flex-col gap-4" for={@changeset} change="change" submit="submit">
         <h1 class="text-2xl">Reset Password</h1>
         <TextInput

--- a/lib/banchan_web/live/auth_live/reset_password_live.ex
+++ b/lib/banchan_web/live/auth_live/reset_password_live.ex
@@ -29,7 +29,7 @@ defmodule BanchanWeb.ResetPasswordLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/reset_password_live.ex
+++ b/lib/banchan_web/live/auth_live/reset_password_live.ex
@@ -28,15 +28,9 @@ defmodule BanchanWeb.ResetPasswordLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <Form class="flex flex-col gap-4" for={@changeset} change="change" submit="submit">
         <h1 class="text-2xl">Reset Password</h1>
         <TextInput

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -56,7 +56,7 @@ defmodule BanchanWeb.SettingsLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -56,6 +56,7 @@ defmodule BanchanWeb.SettingsLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -394,7 +395,7 @@ defmodule BanchanWeb.SettingsLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       <h1 class="text-2xl">Account Settings</h1>
       <div class="divider" />
       <h2 class="text-xl">Appearance</h2>

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -389,7 +389,7 @@ defmodule BanchanWeb.SettingsLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       <h1 class="text-2xl">Account Settings</h1>
       <div class="divider" />
       <h2 class="text-xl">Appearance</h2>

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -55,12 +55,6 @@ defmodule BanchanWeb.SettingsLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("toggle_theme", val, socket) do
     {:noreply,
      socket
@@ -395,7 +389,7 @@ defmodule BanchanWeb.SettingsLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       <h1 class="text-2xl">Account Settings</h1>
       <div class="divider" />
       <h2 class="text-xl">Appearance</h2>

--- a/lib/banchan_web/live/auth_live/setup_mfa_live.ex
+++ b/lib/banchan_web/live/auth_live/setup_mfa_live.ex
@@ -33,6 +33,7 @@ defmodule BanchanWeb.SetupMfaLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -130,7 +131,7 @@ defmodule BanchanWeb.SetupMfaLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <AuthLayout>
       {#if @qrcode_svg && !@totp_activated}
         <h1 class="text-2xl">Your QR Code</h1>
         <br>

--- a/lib/banchan_web/live/auth_live/setup_mfa_live.ex
+++ b/lib/banchan_web/live/auth_live/setup_mfa_live.ex
@@ -125,7 +125,7 @@ defmodule BanchanWeb.SetupMfaLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout flash={@flash}>
+    <AuthLayout flashes={@flash}>
       {#if @qrcode_svg && !@totp_activated}
         <h1 class="text-2xl">Your QR Code</h1>
         <br>

--- a/lib/banchan_web/live/auth_live/setup_mfa_live.ex
+++ b/lib/banchan_web/live/auth_live/setup_mfa_live.ex
@@ -33,7 +33,7 @@ defmodule BanchanWeb.SetupMfaLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/auth_live/setup_mfa_live.ex
+++ b/lib/banchan_web/live/auth_live/setup_mfa_live.ex
@@ -32,12 +32,6 @@ defmodule BanchanWeb.SetupMfaLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("setup_mfa", _, socket) do
     user = socket.assigns.current_user
 
@@ -131,7 +125,7 @@ defmodule BanchanWeb.SetupMfaLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <AuthLayout>
+    <AuthLayout flash={@flash}>
       {#if @qrcode_svg && !@totp_activated}
         <h1 class="text-2xl">Your QR Code</h1>
         <br>

--- a/lib/banchan_web/live/beta_live/confirmation.ex
+++ b/lib/banchan_web/live/beta_live/confirmation.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.BetaLive.Confirmation do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <div id="above-fold" class="md:px-4">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/beta_live/confirmation.ex
+++ b/lib/banchan_web/live/beta_live/confirmation.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.BetaLive.Confirmation do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <div id="above-fold" class="md:px-4">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/beta_live/confirmation.ex
+++ b/lib/banchan_web/live/beta_live/confirmation.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.BetaLive.Confirmation do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/beta_live/confirmation.ex
+++ b/lib/banchan_web/live/beta_live/confirmation.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.BetaLive.Confirmation do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <div id="above-fold" class="md:px-4">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/beta_live/requests.ex
+++ b/lib/banchan_web/live/beta_live/requests.ex
@@ -14,9 +14,9 @@ defmodule BanchanWeb.BetaLive.Requests do
   alias BanchanWeb.Components.Form.Checkbox
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = socket |> assign(uri: uri, show_sent: false, email_filter: "", page: 1)
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+  def handle_params(_params, _uri, socket) do
+    socket = socket |> assign(show_sent: false, email_filter: "", page: 1)
+
     {:noreply, socket |> assign(results: list_requests(socket))}
   end
 
@@ -111,7 +111,7 @@ defmodule BanchanWeb.BetaLive.Requests do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">Manage Invite Requests</h1>
       <div class="divider" />
       <div class="flex flex-col md:flex-row md:flex-wrap gap-2">

--- a/lib/banchan_web/live/beta_live/requests.ex
+++ b/lib/banchan_web/live/beta_live/requests.ex
@@ -16,7 +16,7 @@ defmodule BanchanWeb.BetaLive.Requests do
   @impl true
   def handle_params(_params, uri, socket) do
     socket = socket |> assign(uri: uri, show_sent: false, email_filter: "", page: 1)
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(results: list_requests(socket))}
   end
 

--- a/lib/banchan_web/live/beta_live/requests.ex
+++ b/lib/banchan_web/live/beta_live/requests.ex
@@ -111,7 +111,7 @@ defmodule BanchanWeb.BetaLive.Requests do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">Manage Invite Requests</h1>
       <div class="divider" />
       <div class="flex flex-col md:flex-row md:flex-wrap gap-2">

--- a/lib/banchan_web/live/beta_live/requests.ex
+++ b/lib/banchan_web/live/beta_live/requests.ex
@@ -16,6 +16,7 @@ defmodule BanchanWeb.BetaLive.Requests do
   @impl true
   def handle_params(_params, uri, socket) do
     socket = socket |> assign(uri: uri, show_sent: false, email_filter: "", page: 1)
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(results: list_requests(socket))}
   end
 
@@ -110,7 +111,7 @@ defmodule BanchanWeb.BetaLive.Requests do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">Manage Invite Requests</h1>
       <div class="divider" />
       <div class="flex flex-col md:flex-row md:flex-wrap gap-2">

--- a/lib/banchan_web/live/beta_live/signup.ex
+++ b/lib/banchan_web/live/beta_live/signup.ex
@@ -30,7 +30,7 @@ defmodule BanchanWeb.BetaLive.Signup do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <div id="above-fold" class="md:px-4 mt-20">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/beta_live/signup.ex
+++ b/lib/banchan_web/live/beta_live/signup.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.BetaLive.Signup do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/beta_live/signup.ex
+++ b/lib/banchan_web/live/beta_live/signup.ex
@@ -12,12 +12,6 @@ defmodule BanchanWeb.BetaLive.Signup do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("submit", %{"email" => email}, socket) do
     with {:ok, req} <- Accounts.add_invite_request(email),
          {:ok, _} <- Accounts.deliver_artist_invite_confirmation(req) do
@@ -36,7 +30,7 @@ defmodule BanchanWeb.BetaLive.Signup do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <div id="above-fold" class="md:px-4 mt-20">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/beta_live/signup.ex
+++ b/lib/banchan_web/live/beta_live/signup.ex
@@ -13,6 +13,7 @@ defmodule BanchanWeb.BetaLive.Signup do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -35,7 +36,7 @@ defmodule BanchanWeb.BetaLive.Signup do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <div id="above-fold" class="md:px-4 mt-20">
         <div class="min-h-screen hero">
           <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/commission_live/components/attachment_box.ex
+++ b/lib/banchan_web/live/commission_live/components/attachment_box.ex
@@ -9,11 +9,11 @@ defmodule BanchanWeb.CommissionLive.Components.AttachmentBox do
   alias BanchanWeb.Components.Lightbox
 
   prop base_id, :string, required: true
-  prop commission, :struct, required: true
+  prop commission, :struct, from_context: :commission
   prop attachments, :list, required: true
   prop editing, :boolean, default: false
   prop pending_payment, :boolean, default: false
-  prop current_user_member?, :boolean, default: false
+  prop current_user_member?, :boolean, from_context: :current_user_member?
 
   prop open_preview, :event
   prop remove_attachment, :event

--- a/lib/banchan_web/live/commission_live/components/comment.ex
+++ b/lib/banchan_web/live/commission_live/components/comment.ex
@@ -15,11 +15,11 @@ defmodule BanchanWeb.CommissionLive.Components.Comment do
   alias BanchanWeb.CommissionLive.Components.{AttachmentBox, InvoiceBox}
 
   prop actor, :struct, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
-  prop commission, :struct, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop commission, :struct, from_context: :commission
   prop event, :struct, required: true
-  prop uri, :string, required: true
+  prop uri, :string, from_context: :uri
   prop report_modal_id, :string, required: true
 
   data changeset, :struct
@@ -246,14 +246,7 @@ defmodule BanchanWeb.CommissionLive.Components.Comment do
       {#if @event.invoice}
         <div :if={@event.text} class="divider" />
         <div class="pb-4">
-          <InvoiceBox
-            id={"invoice-box-#{@event.public_id}"}
-            current_user={@current_user}
-            current_user_member?={@current_user_member?}
-            uri={@uri}
-            commission={@commission}
-            event={@event}
-          />
+          <InvoiceBox id={"invoice-box-#{@event.public_id}"} event={@event} />
         </div>
       {/if}
 
@@ -263,12 +256,10 @@ defmodule BanchanWeb.CommissionLive.Components.Comment do
           <AttachmentBox
             base_id={@id <> "-attachments"}
             editing={!is_nil(@changeset)}
-            commission={@commission}
             attachments={@event.attachments}
             open_preview="open_preview"
             remove_attachment="remove_attachment"
             pending_payment={@event.invoice && @event.invoice.required && !Payments.invoice_paid?(@event.invoice)}
-            current_user_member?={@current_user_member?}
           />
         </div>
       {/if}

--- a/lib/banchan_web/live/commission_live/components/comment_box.ex
+++ b/lib/banchan_web/live/commission_live/components/comment_box.ex
@@ -16,9 +16,9 @@ defmodule BanchanWeb.CommissionLive.Components.CommentBox do
     Submit
   }
 
-  prop commission, :struct, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
+  prop commission, :struct, from_context: :commission
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
 
   data changeset, :struct
   data uploads, :map

--- a/lib/banchan_web/live/commission_live/components/commission.ex
+++ b/lib/banchan_web/live/commission_live/components/commission.ex
@@ -25,10 +25,9 @@ defmodule BanchanWeb.CommissionLive.Components.Commission do
   }
 
   prop users, :map, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
   prop commission, :struct, required: true
-  prop uri, :string, required: true
 
   prop subscribed?, :boolean
   prop archived?, :boolean
@@ -61,6 +60,8 @@ defmodule BanchanWeb.CommissionLive.Components.Commission do
             socket.assigns.current_user_member?
           )
       )
+
+    socket = Context.put(socket, commission: socket.assigns.commission)
 
     {:ok, socket}
   end
@@ -216,12 +217,7 @@ defmodule BanchanWeb.CommissionLive.Components.Commission do
               class="rounded-box hover:bg-base-200 p-2 transition-all"
             />
             <div class="divider" />
-            <StatusBox
-              id={@id <> "-status-box"}
-              commission={@commission}
-              current_user={@current_user}
-              current_user_member?={@current_user_member?}
-            />
+            <StatusBox id={@id <> "-status-box"} />
             <div class="divider" />
             <div class="text-lg font-medium">Summary</div>
             <BalanceBox
@@ -232,50 +228,22 @@ defmodule BanchanWeb.CommissionLive.Components.Commission do
             />
             <Collapse id="summary-details" class="px-2">
               <:header><div class="font-medium">Details:</div></:header>
-              <SummaryEditor
-                id={@id <> "-summary-editor"}
-                current_user={@current_user}
-                current_user_member?={@current_user_member?}
-                commission={@commission}
-                allow_edits={@current_user_member?}
-              />
+              <SummaryEditor id={@id <> "-summary-editor"} allow_edits={@current_user_member?} />
             </Collapse>
             {#if @current_user_member?}
               <div class="divider" />
-              <InvoiceCollapse
-                id={@id <> "-invoice-collapse"}
-                commission={@commission}
-                current_user={@current_user}
-                current_user_member?={@current_user_member?}
-              />
+              <InvoiceCollapse id={@id <> "-invoice-collapse"} />
             {/if}
             <div class="divider" />
-            <UploadsBox
-              id={@id <> "-uploads-box"}
-              current_user={@current_user}
-              current_user_member?={@current_user_member?}
-              commission={@commission}
-            />
+            <UploadsBox id={@id <> "-uploads-box"} />
             {bottom_buttons(assigns, true)}
           </div>
           <div class="divider md:hidden" />
           <div class="flex flex-col md:col-span-2 md:order-1">
-            <Timeline
-              uri={@uri}
-              users={@users}
-              commission={@commission}
-              current_user={@current_user}
-              current_user_member?={@current_user_member?}
-              report_modal_id={@id <> "-report-modal"}
-            />
+            <Timeline users={@users} report_modal_id={@id <> "-report-modal"} />
             <div class="divider" />
             <div class="flex flex-col gap-4">
-              <CommentBox
-                id={@id <> "-comment-box"}
-                commission={@commission}
-                current_user={@current_user}
-                current_user_member?={@current_user_member?}
-              />
+              <CommentBox id={@id <> "-comment-box"} />
             </div>
             {bottom_buttons(assigns, false)}
             {#if @commission.terms}

--- a/lib/banchan_web/live/commission_live/components/invoice_box.ex
+++ b/lib/banchan_web/live/commission_live/components/invoice_box.ex
@@ -13,11 +13,11 @@ defmodule BanchanWeb.CommissionLive.Components.InvoiceBox do
   alias BanchanWeb.Components.{Button, Modal}
   alias BanchanWeb.Components.Form.{Submit, TextInput}
 
-  prop current_user_member?, :boolean, required: true
-  prop current_user, :struct, required: true
-  prop commission, :struct, required: true
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop current_user, :struct, from_context: :current_user
+  prop commission, :struct, from_context: :commission
   prop event, :struct, required: true
-  prop uri, :string, required: true
+  prop uri, :string, from_context: :uri
 
   # NOTE: We're not actually going to create an event directly. We're just
   # punning off this for the changeset validation.

--- a/lib/banchan_web/live/commission_live/components/invoice_collapse.ex
+++ b/lib/banchan_web/live/commission_live/components/invoice_collapse.ex
@@ -24,9 +24,9 @@ defmodule BanchanWeb.CommissionLive.Components.InvoiceCollapse do
     TextInput
   }
 
-  prop commission, :struct, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
+  prop commission, :struct, from_context: :commission
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
 
   data changeset, :struct
   data uploads, :map

--- a/lib/banchan_web/live/commission_live/components/status_box.ex
+++ b/lib/banchan_web/live/commission_live/components/status_box.ex
@@ -9,9 +9,9 @@ defmodule BanchanWeb.CommissionLive.Components.StatusBox do
 
   alias BanchanWeb.Components.{Button, Collapse}
 
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
-  prop commission, :struct, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop commission, :struct, from_context: :commission
 
   data invoices_paid?, :boolean
 

--- a/lib/banchan_web/live/commission_live/components/summary_editor.ex
+++ b/lib/banchan_web/live/commission_live/components/summary_editor.ex
@@ -13,9 +13,9 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryEditor do
   alias BanchanWeb.CommissionLive.Components.Summary
   alias BanchanWeb.Components.Modal
 
-  prop commission, :struct, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
+  prop commission, :struct, from_context: :commission
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
   prop allow_edits, :boolean, required: true
 
   data studio, :struct

--- a/lib/banchan_web/live/commission_live/components/timeline.ex
+++ b/lib/banchan_web/live/commission_live/components/timeline.ex
@@ -9,10 +9,9 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
   alias BanchanWeb.CommissionLive.Components.{Comment, TimelineItem}
 
   prop users, :map, required: true
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
-  prop commission, :any, required: true
-  prop uri, :string, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop commission, :any, from_context: :commission
   prop report_modal_id, :string, required: true
 
   def fmt_time(time) do
@@ -39,12 +38,8 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
               <article class="timeline-item scroll-mt-36 snap-start" id={"event-#{event.public_id}"}>
                 <Comment
                   id={"event-#{event.public_id}"}
-                  uri={@uri}
                   actor={Map.get(@users, event.actor_id)}
                   event={event}
-                  commission={@commission}
-                  current_user={@current_user}
-                  current_user_member?={@current_user_member?}
                   report_modal_id={@report_modal_id}
                 />
               </article>
@@ -56,16 +51,15 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
             {#for event <- chunk}
               {#case event.type}
                 {#match :line_item_added}
-                  <TimelineItem uri={@uri} icon="➕" actor={Map.get(@users, event.actor_id)} event={event}>
+                  <TimelineItem icon="➕" actor={Map.get(@users, event.actor_id)} event={event}>
                     added <strong>{event.text}</strong> ({Money.to_string(event.amount)})
                   </TimelineItem>
                 {#match :line_item_removed}
-                  <TimelineItem uri={@uri} icon="✖" actor={Map.get(@users, event.actor_id)} event={event}>
+                  <TimelineItem icon="✖" actor={Map.get(@users, event.actor_id)} event={event}>
                     removed <strong>{event.text}</strong> ({Money.to_string(Money.multiply(event.amount, -1))})
                   </TimelineItem>
                 {#match :payment_processed}
                   <TimelineItem
-                    uri={@uri}
                     icon={Money.Currency.symbol(event.amount)}
                     actor={Map.get(@users, event.actor_id)}
                     event={event}
@@ -74,7 +68,6 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
                   </TimelineItem>
                 {#match :refund_processed}
                   <TimelineItem
-                    uri={@uri}
                     icon={Money.Currency.symbol(event.amount)}
                     actor={Map.get(@users, event.actor_id)}
                     event={event}
@@ -82,11 +75,11 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
                     refunded {Money.to_string(event.amount)}
                   </TimelineItem>
                 {#match :status}
-                  <TimelineItem uri={@uri} icon="S" actor={Map.get(@users, event.actor_id)} event={event}>
+                  <TimelineItem icon="S" actor={Map.get(@users, event.actor_id)} event={event}>
                     changed the status to <strong>{Common.humanize_status(event.status)}</strong>
                   </TimelineItem>
                 {#match :title_changed}
-                  <TimelineItem uri={@uri} icon="T" actor={Map.get(@users, event.actor_id)} event={event}>
+                  <TimelineItem icon="T" actor={Map.get(@users, event.actor_id)} event={event}>
                     changed the title <span class="line-through">{event.text}</span> {@commission.title}
                   </TimelineItem>
               {/case}

--- a/lib/banchan_web/live/commission_live/components/timeline_item.ex
+++ b/lib/banchan_web/live/commission_live/components/timeline_item.ex
@@ -9,7 +9,7 @@ defmodule BanchanWeb.CommissionLive.Components.TimelineItem do
   prop actor, :struct, required: true
   prop event, :struct, required: true
   prop icon, :string, default: ""
-  prop uri, :string, required: true
+  prop uri, :string, from_context: :uri
 
   slot default
 

--- a/lib/banchan_web/live/commission_live/components/uploads_box.ex
+++ b/lib/banchan_web/live/commission_live/components/uploads_box.ex
@@ -9,9 +9,9 @@ defmodule BanchanWeb.CommissionLive.Components.UploadsBox do
   alias BanchanWeb.CommissionLive.Components.AttachmentBox
   alias BanchanWeb.Components.Collapse
 
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
-  prop commission, :struct, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop commission, :struct, from_context: :commission
 
   data attachments, :list
   data loaded, :boolean, default: false
@@ -60,11 +60,7 @@ defmodule BanchanWeb.CommissionLive.Components.UploadsBox do
         <:header>
           <div class="text-lg font-medium">Uploads ({Enum.count(@attachments)})</div>
         </:header>
-        <AttachmentBox
-          base_id={@id <> "-attachments"}
-          commission={@commission}
-          attachments={@attachments}
-        />
+        <AttachmentBox base_id={@id <> "-attachments"} attachments={@attachments} />
       </Collapse>
     </div>
     """

--- a/lib/banchan_web/live/commission_live/index.ex
+++ b/lib/banchan_web/live/commission_live/index.ex
@@ -168,7 +168,7 @@ defmodule BanchanWeb.CommissionLive do
 
     commission = %{socket.assigns.commission | events: events}
     Commission.events_updated("commission")
-      socket = Context.put(socket, commission: commission)
+    socket = Context.put(socket, commission: commission)
     {:noreply, assign(socket, commission: commission)}
   end
 

--- a/lib/banchan_web/live/commission_live/index.ex
+++ b/lib/banchan_web/live/commission_live/index.ex
@@ -96,6 +96,12 @@ defmodule BanchanWeb.CommissionLive do
           assign(socket, commission: nil, users: %{}, current_user_member?: false)
       end
 
+    socket =
+      Context.put(socket,
+        current_user_member?: socket.assigns.current_user_member?,
+        uri: uri
+      )
+
     {:noreply, socket |> assign(:uri, uri)}
   end
 
@@ -430,14 +436,7 @@ defmodule BanchanWeb.CommissionLive do
         </div>
         {#if @commission}
           <div class="basis-full">
-            <Commission
-              id="commission"
-              uri={@uri}
-              users={@users}
-              current_user={@current_user}
-              commission={@commission}
-              current_user_member?={@current_user_member?}
-            />
+            <Commission id="commission" users={@users} commission={@commission} />
           </div>
         {/if}
       </div>

--- a/lib/banchan_web/live/commission_live/index.ex
+++ b/lib/banchan_web/live/commission_live/index.ex
@@ -369,7 +369,7 @@ defmodule BanchanWeb.CommissionLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       {#if !@commission}
         <h1 class="text-3xl">My Commissions</h1>
         <div class="divider" />

--- a/lib/banchan_web/live/commission_live/index.ex
+++ b/lib/banchan_web/live/commission_live/index.ex
@@ -25,7 +25,7 @@ defmodule BanchanWeb.CommissionLive do
 
   @impl true
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  def handle_params(params, uri, socket) do
+  def handle_params(params, _uri, socket) do
     socket =
       socket
       |> assign(
@@ -99,12 +99,10 @@ defmodule BanchanWeb.CommissionLive do
     socket =
       Context.put(socket,
         commission: socket.assigns.commission,
-        current_user_member?: socket.assigns.current_user_member?,
-        uri: uri,
-        flash: socket.assigns.flash
+        current_user_member?: socket.assigns.current_user_member?
       )
 
-    {:noreply, socket |> assign(:uri, uri)}
+    {:noreply, socket}
   end
 
   @impl true
@@ -371,7 +369,7 @@ defmodule BanchanWeb.CommissionLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       {#if !@commission}
         <h1 class="text-3xl">My Commissions</h1>
         <div class="divider" />

--- a/lib/banchan_web/live/commission_live/index.ex
+++ b/lib/banchan_web/live/commission_live/index.ex
@@ -98,8 +98,10 @@ defmodule BanchanWeb.CommissionLive do
 
     socket =
       Context.put(socket,
+        commission: socket.assigns.commission,
         current_user_member?: socket.assigns.current_user_member?,
-        uri: uri
+        uri: uri,
+        flash: socket.assigns.flash
       )
 
     {:noreply, socket |> assign(:uri, uri)}
@@ -129,12 +131,14 @@ defmodule BanchanWeb.CommissionLive do
 
     commission = %{socket.assigns.commission | events: events}
     Commission.events_updated("commission")
+    socket = Context.put(socket, commission: commission)
     {:noreply, assign(socket, users: users, commission: commission)}
   end
 
   def handle_info(%{event: "new_status", payload: status}, socket) do
     if socket.assigns.commission do
       commission = %{socket.assigns.commission | status: status}
+      socket = Context.put(socket, commission: commission)
       {:noreply, assign(socket, commission: commission)}
     else
       {:noreply, socket}
@@ -144,6 +148,7 @@ defmodule BanchanWeb.CommissionLive do
   def handle_info(%{event: "new_title", payload: title}, socket) do
     if socket.assigns.commission do
       commission = %{socket.assigns.commission | title: title}
+      socket = Context.put(socket, commission: commission)
       {:noreply, assign(socket, commission: commission)}
     else
       {:noreply, socket}
@@ -163,12 +168,14 @@ defmodule BanchanWeb.CommissionLive do
 
     commission = %{socket.assigns.commission | events: events}
     Commission.events_updated("commission")
+      socket = Context.put(socket, commission: commission)
     {:noreply, assign(socket, commission: commission)}
   end
 
   def handle_info(%{event: "line_items_changed", payload: line_items}, socket) do
-    {:noreply,
-     socket |> assign(commission: %{socket.assigns.commission | line_items: line_items})}
+    commission = %{socket.assigns.commission | line_items: line_items}
+    socket = Context.put(socket, commission: commission)
+    {:noreply, socket |> assign(commission: commission)}
   end
 
   @impl true
@@ -364,7 +371,7 @@ defmodule BanchanWeb.CommissionLive do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       {#if !@commission}
         <h1 class="text-3xl">My Commissions</h1>
         <div class="divider" />

--- a/lib/banchan_web/live/denizen_live/edit.ex
+++ b/lib/banchan_web/live/denizen_live/edit.ex
@@ -56,6 +56,7 @@ defmodule BanchanWeb.DenizenLive.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -148,7 +149,7 @@ defmodule BanchanWeb.DenizenLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+    <Layout padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form class="profile-info" for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/edit.ex
+++ b/lib/banchan_web/live/denizen_live/edit.ex
@@ -55,12 +55,6 @@ defmodule BanchanWeb.DenizenLive.Edit do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("change", %{"user" => user}, socket) do
     changeset =
       socket.assigns.user
@@ -149,7 +143,7 @@ defmodule BanchanWeb.DenizenLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form class="profile-info" for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/edit.ex
+++ b/lib/banchan_web/live/denizen_live/edit.ex
@@ -56,7 +56,7 @@ defmodule BanchanWeb.DenizenLive.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/denizen_live/edit.ex
+++ b/lib/banchan_web/live/denizen_live/edit.ex
@@ -143,7 +143,7 @@ defmodule BanchanWeb.DenizenLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form class="profile-info" for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/index.ex
+++ b/lib/banchan_web/live/denizen_live/index.ex
@@ -14,7 +14,7 @@ defmodule BanchanWeb.DenizenLive.Index do
   alias BanchanWeb.Components.{Avatar, InfiniteScroll, Layout, UserHandle}
 
   @impl true
-  def handle_params(params, uri, socket) do
+  def handle_params(params, _uri, socket) do
     socket =
       socket
       |> assign(
@@ -31,9 +31,7 @@ defmodule BanchanWeb.DenizenLive.Index do
 
     socket = socket |> assign(results: list_users(socket))
 
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-
-    {:noreply, socket |> assign(uri: uri)}
+    {:noreply, socket}
   end
 
   @impl true
@@ -122,7 +120,7 @@ defmodule BanchanWeb.DenizenLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">Users</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/denizen_live/index.ex
+++ b/lib/banchan_web/live/denizen_live/index.ex
@@ -120,7 +120,7 @@ defmodule BanchanWeb.DenizenLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">Users</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/denizen_live/index.ex
+++ b/lib/banchan_web/live/denizen_live/index.ex
@@ -31,6 +31,8 @@ defmodule BanchanWeb.DenizenLive.Index do
 
     socket = socket |> assign(results: list_users(socket))
 
+    socket = Context.put(socket, uri: uri)
+
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -120,7 +122,7 @@ defmodule BanchanWeb.DenizenLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">Users</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/denizen_live/index.ex
+++ b/lib/banchan_web/live/denizen_live/index.ex
@@ -31,7 +31,7 @@ defmodule BanchanWeb.DenizenLive.Index do
 
     socket = socket |> assign(results: list_users(socket))
 
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
 
     {:noreply, socket |> assign(uri: uri)}
   end

--- a/lib/banchan_web/live/denizen_live/moderation.ex
+++ b/lib/banchan_web/live/denizen_live/moderation.ex
@@ -144,7 +144,7 @@ defmodule BanchanWeb.DenizenLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:user} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/moderation.ex
+++ b/lib/banchan_web/live/denizen_live/moderation.ex
@@ -56,6 +56,7 @@ defmodule BanchanWeb.DenizenLive.Moderation do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -149,7 +150,7 @@ defmodule BanchanWeb.DenizenLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+    <Layout padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:user} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/moderation.ex
+++ b/lib/banchan_web/live/denizen_live/moderation.ex
@@ -55,12 +55,6 @@ defmodule BanchanWeb.DenizenLive.Moderation do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("change", val, socket) do
     changeset =
       User.admin_changeset(socket.assigns.current_user, socket.assigns.user, val["user"])
@@ -150,7 +144,7 @@ defmodule BanchanWeb.DenizenLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:user} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/denizen_live/moderation.ex
+++ b/lib/banchan_web/live/denizen_live/moderation.ex
@@ -56,7 +56,7 @@ defmodule BanchanWeb.DenizenLive.Moderation do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -28,7 +28,8 @@ defmodule BanchanWeb.DenizenLive.Show do
   def handle_params(%{"handle" => handle}, uri, socket) do
     user = Accounts.get_user_by_handle!(handle)
     socket = socket |> assign(user: user)
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+
     {:noreply,
      assign(socket,
        uri: uri,

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -151,7 +151,7 @@ defmodule BanchanWeb.DenizenLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <:hero>
         <section>
           {#if @user.header_img && !@user.header_img.pending && !@user.disable_info}

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -28,7 +28,7 @@ defmodule BanchanWeb.DenizenLive.Show do
   def handle_params(%{"handle" => handle}, uri, socket) do
     user = Accounts.get_user_by_handle!(handle)
     socket = socket |> assign(user: user)
-
+    socket = Context.put(socket, uri: uri)
     {:noreply,
      assign(socket,
        uri: uri,
@@ -152,7 +152,7 @@ defmodule BanchanWeb.DenizenLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <:hero>
         <section>
           {#if @user.header_img && !@user.header_img.pending && !@user.disable_info}

--- a/lib/banchan_web/live/denizen_live/show.ex
+++ b/lib/banchan_web/live/denizen_live/show.ex
@@ -25,14 +25,12 @@ defmodule BanchanWeb.DenizenLive.Show do
   alias BanchanWeb.Endpoint
 
   @impl true
-  def handle_params(%{"handle" => handle}, uri, socket) do
+  def handle_params(%{"handle" => handle}, _uri, socket) do
     user = Accounts.get_user_by_handle!(handle)
     socket = socket |> assign(user: user)
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
 
     {:noreply,
      assign(socket,
-       uri: uri,
        studios: list_studios(socket),
        following: Studios.Notifications.following_count(user),
        page_title: "#{user.name} (@#{user.handle})",
@@ -153,7 +151,7 @@ defmodule BanchanWeb.DenizenLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <:hero>
         <section>
           {#if @user.header_img && !@user.header_img.pending && !@user.disable_info}

--- a/lib/banchan_web/live/discover_live/index.ex
+++ b/lib/banchan_web/live/discover_live/index.ex
@@ -13,6 +13,7 @@ defmodule BanchanWeb.DiscoverLive.Index do
   @impl true
   def handle_params(params, uri, socket) do
     socket = param_filters(socket, params)
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -116,7 +117,7 @@ defmodule BanchanWeb.DiscoverLive.Index do
       end
 
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">Discover</h1>
       <div class="divider" />
       <div class="tabs tabs-boxed flex flex-nowrap max-w-xl mx-auto">

--- a/lib/banchan_web/live/discover_live/index.ex
+++ b/lib/banchan_web/live/discover_live/index.ex
@@ -11,10 +11,10 @@ defmodule BanchanWeb.DiscoverLive.Index do
   alias BanchanWeb.DiscoverLive.Components.{Offerings, Studios}
 
   @impl true
-  def handle_params(params, uri, socket) do
+  def handle_params(params, _uri, socket) do
     socket = param_filters(socket, params)
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -117,7 +117,7 @@ defmodule BanchanWeb.DiscoverLive.Index do
       end
 
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">Discover</h1>
       <div class="divider" />
       <div class="tabs tabs-boxed flex flex-nowrap max-w-xl mx-auto">

--- a/lib/banchan_web/live/discover_live/index.ex
+++ b/lib/banchan_web/live/discover_live/index.ex
@@ -117,7 +117,7 @@ defmodule BanchanWeb.DiscoverLive.Index do
       end
 
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">Discover</h1>
       <div class="divider" />
       <div class="tabs tabs-boxed flex flex-nowrap max-w-xl mx-auto">

--- a/lib/banchan_web/live/discover_live/index.ex
+++ b/lib/banchan_web/live/discover_live/index.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.DiscoverLive.Index do
   @impl true
   def handle_params(params, uri, socket) do
     socket = param_filters(socket, params)
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/home_live/index.ex
+++ b/lib/banchan_web/live/home_live/index.ex
@@ -57,6 +57,7 @@ defmodule BanchanWeb.HomeLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -80,7 +81,7 @@ defmodule BanchanWeb.HomeLive do
   def render(assigns) do
     ~F"""
     {#if @current_user || is_nil(Application.get_env(:banchan, :basic_auth))}
-      <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+      <Layout>
         <:hero>
           <div id="carousel-handler" class="flex-grow">
             <Carousel
@@ -172,7 +173,7 @@ defmodule BanchanWeb.HomeLive do
         </div>
       </Layout>
     {#else}
-      <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+      <Layout>
         <div id="above-fold" class="md:px-4">
           <div class="min-h-screen hero">
             <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/home_live/index.ex
+++ b/lib/banchan_web/live/home_live/index.ex
@@ -75,7 +75,7 @@ defmodule BanchanWeb.HomeLive do
   def render(assigns) do
     ~F"""
     {#if @current_user || is_nil(Application.get_env(:banchan, :basic_auth))}
-      <Layout flash={@flash}>
+      <Layout flashes={@flash}>
         <:hero>
           <div id="carousel-handler" class="flex-grow">
             <Carousel
@@ -167,7 +167,7 @@ defmodule BanchanWeb.HomeLive do
         </div>
       </Layout>
     {#else}
-      <Layout flash={@flash}>
+      <Layout flashes={@flash}>
         <div id="above-fold" class="md:px-4">
           <div class="min-h-screen hero">
             <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/home_live/index.ex
+++ b/lib/banchan_web/live/home_live/index.ex
@@ -57,7 +57,7 @@ defmodule BanchanWeb.HomeLive do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/home_live/index.ex
+++ b/lib/banchan_web/live/home_live/index.ex
@@ -56,12 +56,6 @@ defmodule BanchanWeb.HomeLive do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("search", search, socket) do
     params = []
 
@@ -81,7 +75,7 @@ defmodule BanchanWeb.HomeLive do
   def render(assigns) do
     ~F"""
     {#if @current_user || is_nil(Application.get_env(:banchan, :basic_auth))}
-      <Layout>
+      <Layout flash={@flash}>
         <:hero>
           <div id="carousel-handler" class="flex-grow">
             <Carousel
@@ -173,7 +167,7 @@ defmodule BanchanWeb.HomeLive do
         </div>
       </Layout>
     {#else}
-      <Layout>
+      <Layout flash={@flash}>
         <div id="above-fold" class="md:px-4">
           <div class="min-h-screen hero">
             <div class="hero-content flex flex-col md:flex-row">

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -21,6 +21,7 @@ defmodule BanchanWeb.OfferingLive.Request do
   @impl true
   def handle_params(%{"offering_type" => offering_type} = params, uri, socket) do
     socket = assign_studio_defaults(params, socket, false, true)
+    socket = Context.put(socket, uri: uri)
 
     offering =
       Offerings.get_offering_by_type!(
@@ -304,7 +305,7 @@ defmodule BanchanWeb.OfferingLive.Request do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout current_user={@current_user} flashes={@flash} uri={@uri}>
+    <Layout>
       <h1 class="text-2xl font-bold">Request a Commission</h1>
       <div class="divider" />
       <div class="flex flex-col space-y-2 md:container md:mx-auto p-2">

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -21,7 +21,7 @@ defmodule BanchanWeb.OfferingLive.Request do
   @impl true
   def handle_params(%{"offering_type" => offering_type} = params, uri, socket) do
     socket = assign_studio_defaults(params, socket, false, true)
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
 
     offering =
       Offerings.get_offering_by_type!(

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -19,9 +19,8 @@ defmodule BanchanWeb.OfferingLive.Request do
   alias BanchanWeb.Endpoint
 
   @impl true
-  def handle_params(%{"offering_type" => offering_type} = params, uri, socket) do
+  def handle_params(%{"offering_type" => offering_type} = params, _uri, socket) do
     socket = assign_studio_defaults(params, socket, false, true)
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
 
     offering =
       Offerings.get_offering_by_type!(
@@ -64,7 +63,6 @@ defmodule BanchanWeb.OfferingLive.Request do
         {:noreply,
          socket
          |> assign(
-           uri: uri,
            changeset: Commission.creation_changeset(%Commission{}, %{}),
            line_items: default_items,
            offering: offering,
@@ -305,7 +303,7 @@ defmodule BanchanWeb.OfferingLive.Request do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-2xl font-bold">Request a Commission</h1>
       <div class="divider" />
       <div class="flex flex-col space-y-2 md:container md:mx-auto p-2">

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -303,7 +303,7 @@ defmodule BanchanWeb.OfferingLive.Request do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-2xl font-bold">Request a Commission</h1>
       <div class="divider" />
       <div class="flex flex-col space-y-2 md:container md:mx-auto p-2">

--- a/lib/banchan_web/live/offering_live/show.ex
+++ b/lib/banchan_web/live/offering_live/show.ex
@@ -36,7 +36,8 @@ defmodule BanchanWeb.OfferingLive.Show do
 
     socket = assign_studio_defaults(params, socket, false, true)
 
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+
     offering =
       Offerings.get_offering_by_type!(
         socket.assigns.current_user,

--- a/lib/banchan_web/live/offering_live/show.ex
+++ b/lib/banchan_web/live/offering_live/show.ex
@@ -36,6 +36,7 @@ defmodule BanchanWeb.OfferingLive.Show do
 
     socket = assign_studio_defaults(params, socket, false, true)
 
+    socket = Context.put(socket, uri: uri)
     offering =
       Offerings.get_offering_by_type!(
         socket.assigns.current_user,
@@ -175,7 +176,7 @@ defmodule BanchanWeb.OfferingLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">
         {@offering.name}
       </h1>

--- a/lib/banchan_web/live/offering_live/show.ex
+++ b/lib/banchan_web/live/offering_live/show.ex
@@ -174,7 +174,7 @@ defmodule BanchanWeb.OfferingLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">
         {@offering.name}
       </h1>

--- a/lib/banchan_web/live/offering_live/show.ex
+++ b/lib/banchan_web/live/offering_live/show.ex
@@ -29,14 +29,12 @@ defmodule BanchanWeb.OfferingLive.Show do
 
   @impl true
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  def handle_params(%{"offering_type" => offering_type} = params, uri, socket) do
+  def handle_params(%{"offering_type" => offering_type} = params, _uri, socket) do
     if socket.assigns[:offering] do
       Notifications.unsubscribe_from_offering_updates(socket.assigns.offering)
     end
 
     socket = assign_studio_defaults(params, socket, false, true)
-
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
 
     offering =
       Offerings.get_offering_by_type!(
@@ -101,7 +99,6 @@ defmodule BanchanWeb.OfferingLive.Show do
         {:noreply,
          socket
          |> assign(
-           uri: uri,
            offering: offering,
            gallery_images: gallery_images,
            line_items: line_items,
@@ -177,7 +174,7 @@ defmodule BanchanWeb.OfferingLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">
         {@offering.name}
       </h1>

--- a/lib/banchan_web/live/report_bug_live/new.ex
+++ b/lib/banchan_web/live/report_bug_live/new.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.ReportBugLive.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, assign(socket, uri: uri, report_url: nil)}
   end
 

--- a/lib/banchan_web/live/report_bug_live/new.ex
+++ b/lib/banchan_web/live/report_bug_live/new.ex
@@ -12,9 +12,8 @@ defmodule BanchanWeb.ReportBugLive.New do
   alias BanchanWeb.Components.Form.{MarkdownInput, Submit, TextInput}
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, assign(socket, uri: uri, report_url: nil)}
+  def handle_params(_params, _uri, socket) do
+    {:noreply, assign(socket, report_url: nil)}
   end
 
   @impl true
@@ -45,7 +44,7 @@ defmodule BanchanWeb.ReportBugLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-lg w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           {#if @report_url}

--- a/lib/banchan_web/live/report_bug_live/new.ex
+++ b/lib/banchan_web/live/report_bug_live/new.ex
@@ -44,7 +44,7 @@ defmodule BanchanWeb.ReportBugLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-lg w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           {#if @report_url}

--- a/lib/banchan_web/live/report_bug_live/new.ex
+++ b/lib/banchan_web/live/report_bug_live/new.ex
@@ -13,6 +13,7 @@ defmodule BanchanWeb.ReportBugLive.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, assign(socket, uri: uri, report_url: nil)}
   end
 
@@ -44,7 +45,7 @@ defmodule BanchanWeb.ReportBugLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+    <Layout padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-lg w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           {#if @report_url}

--- a/lib/banchan_web/live/report_live/index.ex
+++ b/lib/banchan_web/live/report_live/index.ex
@@ -23,6 +23,7 @@ defmodule BanchanWeb.ReportLive.Index do
 
   @impl true
   def handle_params(params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     socket =
       socket
       |> assign(
@@ -205,7 +206,7 @@ defmodule BanchanWeb.ReportLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">Reports</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/report_live/index.ex
+++ b/lib/banchan_web/live/report_live/index.ex
@@ -22,9 +22,7 @@ defmodule BanchanWeb.ReportLive.Index do
   ]
 
   @impl true
-  def handle_params(params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-
+  def handle_params(params, _uri, socket) do
     socket =
       socket
       |> assign(
@@ -45,7 +43,7 @@ defmodule BanchanWeb.ReportLive.Index do
         list_reports(socket)
       )
 
-    {:noreply, socket |> assign(uri: uri)}
+    {:noreply, socket}
   end
 
   @impl true
@@ -207,7 +205,7 @@ defmodule BanchanWeb.ReportLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">Reports</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/report_live/index.ex
+++ b/lib/banchan_web/live/report_live/index.ex
@@ -23,7 +23,8 @@ defmodule BanchanWeb.ReportLive.Index do
 
   @impl true
   def handle_params(params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+
     socket =
       socket
       |> assign(

--- a/lib/banchan_web/live/report_live/index.ex
+++ b/lib/banchan_web/live/report_live/index.ex
@@ -205,7 +205,7 @@ defmodule BanchanWeb.ReportLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">Reports</h1>
       <div class="divider" />
       <div class="flex flex-col pt-4">

--- a/lib/banchan_web/live/report_live/show.ex
+++ b/lib/banchan_web/live/report_live/show.ex
@@ -14,6 +14,7 @@ defmodule BanchanWeb.ReportLive.Show do
 
   @impl true
   def handle_params(%{"id" => report_id}, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     report = Reports.get_report_by_id!(report_id)
 
     {:noreply,
@@ -108,7 +109,7 @@ defmodule BanchanWeb.ReportLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <div class="relative">
         <h1 class="text-3xl flex flex-row items-center px-4 sticky top-16 bg-base-100 z-30 pb-2 border-b-2 border-base-content border-opacity-10 opacity-100 items-center">
           <LiveRedirect class="px-2 pb-4" to={Routes.report_index_path(Endpoint, :index)}>

--- a/lib/banchan_web/live/report_live/show.ex
+++ b/lib/banchan_web/live/report_live/show.ex
@@ -107,7 +107,7 @@ defmodule BanchanWeb.ReportLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <div class="relative">
         <h1 class="text-3xl flex flex-row items-center px-4 sticky top-16 bg-base-100 z-30 pb-2 border-b-2 border-base-content border-opacity-10 opacity-100 items-center">
           <LiveRedirect class="px-2 pb-4" to={Routes.report_index_path(Endpoint, :index)}>

--- a/lib/banchan_web/live/report_live/show.ex
+++ b/lib/banchan_web/live/report_live/show.ex
@@ -13,14 +13,12 @@ defmodule BanchanWeb.ReportLive.Show do
   alias BanchanWeb.Components.Form.{MarkdownInput, Select, Submit}
 
   @impl true
-  def handle_params(%{"id" => report_id}, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+  def handle_params(%{"id" => report_id}, _uri, socket) do
     report = Reports.get_report_by_id!(report_id)
 
     {:noreply,
      socket
      |> assign(
-       uri: uri,
        report: report,
        changeset: Report.update_changeset(report, %{})
      )}
@@ -109,7 +107,7 @@ defmodule BanchanWeb.ReportLive.Show do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <div class="relative">
         <h1 class="text-3xl flex flex-row items-center px-4 sticky top-16 bg-base-100 z-30 pb-2 border-b-2 border-base-content border-opacity-10 opacity-100 items-center">
           <LiveRedirect class="px-2 pb-4" to={Routes.report_index_path(Endpoint, :index)}>

--- a/lib/banchan_web/live/report_live/show.ex
+++ b/lib/banchan_web/live/report_live/show.ex
@@ -14,7 +14,7 @@ defmodule BanchanWeb.ReportLive.Show do
 
   @impl true
   def handle_params(%{"id" => report_id}, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     report = Reports.get_report_by_id!(report_id)
 
     {:noreply,

--- a/lib/banchan_web/live/static_live/about_us_live.ex
+++ b/lib/banchan_web/live/static_live/about_us_live.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.AboutUs do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/about_us_live.ex
+++ b/lib/banchan_web/live/static_live/about_us_live.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.AboutUs do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # About Banchan Art
 

--- a/lib/banchan_web/live/static_live/about_us_live.ex
+++ b/lib/banchan_web/live/static_live/about_us_live.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.AboutUs do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # About Banchan Art
 

--- a/lib/banchan_web/live/static_live/about_us_live.ex
+++ b/lib/banchan_web/live/static_live/about_us_live.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.AboutUs do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # About Banchan Art
 

--- a/lib/banchan_web/live/static_live/contact_live.ex
+++ b/lib/banchan_web/live/static_live/contact_live.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.Contact do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Contact Us
 

--- a/lib/banchan_web/live/static_live/contact_live.ex
+++ b/lib/banchan_web/live/static_live/contact_live.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.Contact do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/contact_live.ex
+++ b/lib/banchan_web/live/static_live/contact_live.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.Contact do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Contact Us
 

--- a/lib/banchan_web/live/static_live/contact_live.ex
+++ b/lib/banchan_web/live/static_live/contact_live.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.Contact do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Contact Us
 

--- a/lib/banchan_web/live/static_live/cookies_policy.ex
+++ b/lib/banchan_web/live/static_live/cookies_policy.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.CookiesPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/cookies_policy.ex
+++ b/lib/banchan_web/live/static_live/cookies_policy.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.CookiesPolicy do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Cookies Policy
 

--- a/lib/banchan_web/live/static_live/cookies_policy.ex
+++ b/lib/banchan_web/live/static_live/cookies_policy.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.CookiesPolicy do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Cookies Policy
 

--- a/lib/banchan_web/live/static_live/cookies_policy.ex
+++ b/lib/banchan_web/live/static_live/cookies_policy.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.CookiesPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Cookies Policy
 

--- a/lib/banchan_web/live/static_live/disputes_policy.ex
+++ b/lib/banchan_web/live/static_live/disputes_policy.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.DisputesPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Disputes Policy
 

--- a/lib/banchan_web/live/static_live/disputes_policy.ex
+++ b/lib/banchan_web/live/static_live/disputes_policy.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.DisputesPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/disputes_policy.ex
+++ b/lib/banchan_web/live/static_live/disputes_policy.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.DisputesPolicy do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Disputes Policy
 

--- a/lib/banchan_web/live/static_live/disputes_policy.ex
+++ b/lib/banchan_web/live/static_live/disputes_policy.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.DisputesPolicy do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Disputes Policy
 

--- a/lib/banchan_web/live/static_live/membership_live.ex
+++ b/lib/banchan_web/live/static_live/membership_live.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.Membership do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Joining Banchan
 

--- a/lib/banchan_web/live/static_live/membership_live.ex
+++ b/lib/banchan_web/live/static_live/membership_live.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.Membership do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Joining Banchan
 

--- a/lib/banchan_web/live/static_live/membership_live.ex
+++ b/lib/banchan_web/live/static_live/membership_live.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.Membership do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/membership_live.ex
+++ b/lib/banchan_web/live/static_live/membership_live.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.Membership do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Joining Banchan
 

--- a/lib/banchan_web/live/static_live/privacy_policy_live.ex
+++ b/lib/banchan_web/live/static_live/privacy_policy_live.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.PrivacyPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Privacy Policy
 

--- a/lib/banchan_web/live/static_live/privacy_policy_live.ex
+++ b/lib/banchan_web/live/static_live/privacy_policy_live.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.PrivacyPolicy do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Privacy Policy
 

--- a/lib/banchan_web/live/static_live/privacy_policy_live.ex
+++ b/lib/banchan_web/live/static_live/privacy_policy_live.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.PrivacyPolicy do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/static_live/privacy_policy_live.ex
+++ b/lib/banchan_web/live/static_live/privacy_policy_live.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.PrivacyPolicy do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Privacy Policy
 

--- a/lib/banchan_web/live/static_live/terms_and_conditions.ex
+++ b/lib/banchan_web/live/static_live/terms_and_conditions.ex
@@ -9,15 +9,9 @@ defmodule BanchanWeb.StaticLive.TermsAndConditions do
   alias BanchanWeb.Components.Layout
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <#Markdown class="prose">
         # Terms and Conditions
 

--- a/lib/banchan_web/live/static_live/terms_and_conditions.ex
+++ b/lib/banchan_web/live/static_live/terms_and_conditions.ex
@@ -11,7 +11,7 @@ defmodule BanchanWeb.StaticLive.TermsAndConditions do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <#Markdown class="prose">
         # Terms and Conditions
 

--- a/lib/banchan_web/live/static_live/terms_and_conditions.ex
+++ b/lib/banchan_web/live/static_live/terms_and_conditions.ex
@@ -10,13 +10,14 @@ defmodule BanchanWeb.StaticLive.TermsAndConditions do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <#Markdown class="prose">
         # Terms and Conditions
 

--- a/lib/banchan_web/live/static_live/terms_and_conditions.ex
+++ b/lib/banchan_web/live/static_live/terms_and_conditions.ex
@@ -10,7 +10,7 @@ defmodule BanchanWeb.StaticLive.TermsAndConditions do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/studio_live/about.ex
+++ b/lib/banchan_web/live/studio_live/about.ex
@@ -19,7 +19,7 @@ defmodule BanchanWeb.StudioLive.About do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:about}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} tab={:about}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Markdown content={@studio.about} />

--- a/lib/banchan_web/live/studio_live/about.ex
+++ b/lib/banchan_web/live/studio_live/about.ex
@@ -18,18 +18,14 @@ defmodule BanchanWeb.StudioLive.About do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:about}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} tab={:about}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Markdown content={@studio.about} />

--- a/lib/banchan_web/live/studio_live/about.ex
+++ b/lib/banchan_web/live/studio_live/about.ex
@@ -18,6 +18,7 @@ defmodule BanchanWeb.StudioLive.About do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -26,12 +27,8 @@ defmodule BanchanWeb.StudioLive.About do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:about}
-      uri={@uri}
     >
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">

--- a/lib/banchan_web/live/studio_live/about.ex
+++ b/lib/banchan_web/live/studio_live/about.ex
@@ -17,15 +17,9 @@ defmodule BanchanWeb.StudioLive.About do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} tab={:about}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:about}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Markdown content={@studio.about} />

--- a/lib/banchan_web/live/studio_live/components/studio_layout.ex
+++ b/lib/banchan_web/live/studio_live/components/studio_layout.ex
@@ -12,12 +12,10 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
   alias BanchanWeb.Endpoint
   alias BanchanWeb.StudioLive.Components.{FeaturedToggle, FollowerCountLive, TabButton}
 
-  prop current_user, :struct, required: true
-  prop current_user_member?, :boolean, required: true
-  prop flashes, :string, required: true
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
   prop studio, :struct, required: true
   prop tab, :atom
-  prop uri, :string, required: true
   prop padding, :integer
 
   data follower_count, :integer, from_context: :follower_count
@@ -72,7 +70,7 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
 
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={@padding} current_user={@current_user} flashes={@flashes}>
+    <Layout padding={@padding}>
       <:hero>
         <section>
           {#if @studio.header_img && !@studio.header_img.pending && !@studio.disable_info}

--- a/lib/banchan_web/live/studio_live/components/studio_layout.ex
+++ b/lib/banchan_web/live/studio_live/components/studio_layout.ex
@@ -17,6 +17,7 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
   prop studio, :struct, required: true
   prop tab, :atom
   prop padding, :integer
+  prop flash, :any, required: true
 
   data follower_count, :integer, from_context: :follower_count
   data user_following?, :boolean
@@ -70,7 +71,7 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
 
   def render(assigns) do
     ~F"""
-    <Layout padding={@padding}>
+    <Layout flash={@flash} padding={@padding}>
       <:hero>
         <section>
           {#if @studio.header_img && !@studio.header_img.pending && !@studio.disable_info}

--- a/lib/banchan_web/live/studio_live/components/studio_layout.ex
+++ b/lib/banchan_web/live/studio_live/components/studio_layout.ex
@@ -17,7 +17,7 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
   prop studio, :struct, required: true
   prop tab, :atom
   prop padding, :integer
-  prop flash, :any, required: true
+  prop flashes, :any, required: true
 
   data follower_count, :integer, from_context: :follower_count
   data user_following?, :boolean
@@ -71,7 +71,7 @@ defmodule BanchanWeb.StudioLive.Components.StudioLayout do
 
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={@padding}>
+    <Layout flashes={@flashes} padding={@padding}>
       <:hero>
         <section>
           {#if @studio.header_img && !@studio.header_img.pending && !@studio.disable_info}

--- a/lib/banchan_web/live/studio_live/disabled.ex
+++ b/lib/banchan_web/live/studio_live/disabled.ex
@@ -16,17 +16,14 @@ defmodule BanchanWeb.StudioLive.Disabled do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-    >
+    <StudioLayout id="studio-layout" studio={@studio}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           This studio has been disabled by site administrators.

--- a/lib/banchan_web/live/studio_live/disabled.ex
+++ b/lib/banchan_web/live/studio_live/disabled.ex
@@ -16,6 +16,7 @@ defmodule BanchanWeb.StudioLive.Disabled do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -24,11 +25,7 @@ defmodule BanchanWeb.StudioLive.Disabled do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
-      uri={@uri}
     >
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">

--- a/lib/banchan_web/live/studio_live/disabled.ex
+++ b/lib/banchan_web/live/studio_live/disabled.ex
@@ -15,15 +15,9 @@ defmodule BanchanWeb.StudioLive.Disabled do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           This studio has been disabled by site administrators.

--- a/lib/banchan_web/live/studio_live/disabled.ex
+++ b/lib/banchan_web/live/studio_live/disabled.ex
@@ -17,7 +17,7 @@ defmodule BanchanWeb.StudioLive.Disabled do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio}>
       <div class="w-full mx-auto md:bg-base-300">
         <div class="max-w-prose w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           This studio has been disabled by site administrators.

--- a/lib/banchan_web/live/studio_live/edit.ex
+++ b/lib/banchan_web/live/studio_live/edit.ex
@@ -50,6 +50,7 @@ defmodule BanchanWeb.StudioLive.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -147,12 +148,8 @@ defmodule BanchanWeb.StudioLive.Edit do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       padding={0}
-      uri={@uri}
     >
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">

--- a/lib/banchan_web/live/studio_live/edit.ex
+++ b/lib/banchan_web/live/studio_live/edit.ex
@@ -140,7 +140,7 @@ defmodule BanchanWeb.StudioLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} padding={0}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Edit Studio Profile</h2>

--- a/lib/banchan_web/live/studio_live/edit.ex
+++ b/lib/banchan_web/live/studio_live/edit.ex
@@ -48,12 +48,6 @@ defmodule BanchanWeb.StudioLive.Edit do
      )}
   end
 
-  @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def handle_event("submit", val, socket) do
     card_image =
@@ -146,7 +140,7 @@ defmodule BanchanWeb.StudioLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} padding={0}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Edit Studio Profile</h2>

--- a/lib/banchan_web/live/studio_live/edit.ex
+++ b/lib/banchan_web/live/studio_live/edit.ex
@@ -50,7 +50,7 @@ defmodule BanchanWeb.StudioLive.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -146,11 +146,7 @@ defmodule BanchanWeb.StudioLive.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      padding={0}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Edit Studio Profile</h2>

--- a/lib/banchan_web/live/studio_live/followers.ex
+++ b/lib/banchan_web/live/studio_live/followers.ex
@@ -46,7 +46,7 @@ defmodule BanchanWeb.StudioLive.Followers do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio}>
       <h3 class="p-6 text-semibold text-2xl">Followers</h3>
       <ul class="grid sm:px-2 grid grid-cols-2 sm:gap-2 sm:grid-cols-4 auto-rows-fr">
         {#for user <- @followers}

--- a/lib/banchan_web/live/studio_live/followers.ex
+++ b/lib/banchan_web/live/studio_live/followers.ex
@@ -23,7 +23,7 @@ defmodule BanchanWeb.StudioLive.Followers do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -52,10 +52,7 @@ defmodule BanchanWeb.StudioLive.Followers do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-    >
+    <StudioLayout id="studio-layout" studio={@studio}>
       <h3 class="p-6 text-semibold text-2xl">Followers</h3>
       <ul class="grid sm:px-2 grid grid-cols-2 sm:gap-2 sm:grid-cols-4 auto-rows-fr">
         {#for user <- @followers}

--- a/lib/banchan_web/live/studio_live/followers.ex
+++ b/lib/banchan_web/live/studio_live/followers.ex
@@ -22,12 +22,6 @@ defmodule BanchanWeb.StudioLive.Followers do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("load_more", _, socket) do
     if socket.assigns.followers.total_entries >
          socket.assigns.followers.page_number * socket.assigns.followers.page_size do
@@ -52,7 +46,7 @@ defmodule BanchanWeb.StudioLive.Followers do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
       <h3 class="p-6 text-semibold text-2xl">Followers</h3>
       <ul class="grid sm:px-2 grid grid-cols-2 sm:gap-2 sm:grid-cols-4 auto-rows-fr">
         {#for user <- @followers}

--- a/lib/banchan_web/live/studio_live/followers.ex
+++ b/lib/banchan_web/live/studio_live/followers.ex
@@ -23,6 +23,7 @@ defmodule BanchanWeb.StudioLive.Followers do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -53,11 +54,7 @@ defmodule BanchanWeb.StudioLive.Followers do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
-      uri={@uri}
     >
       <h3 class="p-6 text-semibold text-2xl">Followers</h3>
       <ul class="grid sm:px-2 grid grid-cols-2 sm:gap-2 sm:grid-cols-4 auto-rows-fr">

--- a/lib/banchan_web/live/studio_live/index.ex
+++ b/lib/banchan_web/live/studio_live/index.ex
@@ -36,13 +36,14 @@ defmodule BanchanWeb.StudioLive.Index do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} current_user={@current_user} flashes={@flash}>
+    <Layout>
       <h1 class="text-3xl">My Studios</h1>
       <div class="divider" />
       <div class="studio-list grid grid-cols-1 sm:gap-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-fr">

--- a/lib/banchan_web/live/studio_live/index.ex
+++ b/lib/banchan_web/live/studio_live/index.ex
@@ -37,7 +37,7 @@ defmodule BanchanWeb.StudioLive.Index do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash}>
+    <Layout flashes={@flash}>
       <h1 class="text-3xl">My Studios</h1>
       <div class="divider" />
       <div class="studio-list grid grid-cols-1 sm:gap-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-fr">

--- a/lib/banchan_web/live/studio_live/index.ex
+++ b/lib/banchan_web/live/studio_live/index.ex
@@ -36,7 +36,7 @@ defmodule BanchanWeb.StudioLive.Index do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/studio_live/index.ex
+++ b/lib/banchan_web/live/studio_live/index.ex
@@ -35,15 +35,9 @@ defmodule BanchanWeb.StudioLive.Index do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def render(assigns) do
     ~F"""
-    <Layout>
+    <Layout flash={@flash}>
       <h1 class="text-3xl">My Studios</h1>
       <div class="divider" />
       <div class="studio-list grid grid-cols-1 sm:gap-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-fr">

--- a/lib/banchan_web/live/studio_live/moderation.ex
+++ b/lib/banchan_web/live/studio_live/moderation.ex
@@ -67,12 +67,6 @@ defmodule BanchanWeb.StudioLive.Moderation do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("change", %{"studio" => studio}, socket) do
     changeset =
       Studio.admin_changeset(socket.assigns.studio, studio)
@@ -170,7 +164,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:studio} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/moderation.ex
+++ b/lib/banchan_web/live/studio_live/moderation.ex
@@ -164,7 +164,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:studio} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/moderation.ex
+++ b/lib/banchan_web/live/studio_live/moderation.ex
@@ -68,7 +68,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -170,10 +170,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-    >
+    <StudioLayout id="studio-layout" studio={@studio}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form as={:studio} for={@changeset} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/moderation.ex
+++ b/lib/banchan_web/live/studio_live/moderation.ex
@@ -68,6 +68,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -171,11 +172,7 @@ defmodule BanchanWeb.StudioLive.Moderation do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
-      uri={@uri}
     >
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">

--- a/lib/banchan_web/live/studio_live/new.ex
+++ b/lib/banchan_web/live/studio_live/new.ex
@@ -58,7 +58,7 @@ defmodule BanchanWeb.StudioLive.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 

--- a/lib/banchan_web/live/studio_live/new.ex
+++ b/lib/banchan_web/live/studio_live/new.ex
@@ -58,6 +58,7 @@ defmodule BanchanWeb.StudioLive.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -99,7 +100,7 @@ defmodule BanchanWeb.StudioLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout uri={@uri} padding={0} current_user={@current_user} flashes={@flash}>
+    <Layout padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form

--- a/lib/banchan_web/live/studio_live/new.ex
+++ b/lib/banchan_web/live/studio_live/new.ex
@@ -57,12 +57,6 @@ defmodule BanchanWeb.StudioLive.New do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("change", %{"studio" => studio, "_target" => target}, socket) do
     studio =
       if target == ["studio", "name"] do
@@ -100,7 +94,7 @@ defmodule BanchanWeb.StudioLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout padding={0}>
+    <Layout flash={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form

--- a/lib/banchan_web/live/studio_live/new.ex
+++ b/lib/banchan_web/live/studio_live/new.ex
@@ -94,7 +94,7 @@ defmodule BanchanWeb.StudioLive.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Layout flash={@flash} padding={0}>
+    <Layout flashes={@flash} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-sm w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <Form

--- a/lib/banchan_web/live/studio_live/offerings/edit.ex
+++ b/lib/banchan_web/live/studio_live/offerings/edit.ex
@@ -26,6 +26,7 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -40,12 +41,8 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
     ~F"""
     <Components.StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:shop}
-      uri={@uri}
     >
       <div>
         <div class="p-6 max-w-lg mx-auto">

--- a/lib/banchan_web/live/studio_live/offerings/edit.ex
+++ b/lib/banchan_web/live/studio_live/offerings/edit.ex
@@ -33,7 +33,7 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout id="studio-layout" flash={@flash} studio={@studio} tab={:shop}>
+    <Components.StudioLayout id="studio-layout" flashes={@flash} studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">Edit Offering</h1>

--- a/lib/banchan_web/live/studio_live/offerings/edit.ex
+++ b/lib/banchan_web/live/studio_live/offerings/edit.ex
@@ -26,7 +26,7 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -39,11 +39,7 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:shop}
-    >
+    <Components.StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">Edit Offering</h1>

--- a/lib/banchan_web/live/studio_live/offerings/edit.ex
+++ b/lib/banchan_web/live/studio_live/offerings/edit.ex
@@ -24,12 +24,6 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
     {:ok, assign(socket, offering: offering, gallery_images: nil)}
   end
 
-  @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
   def handle_info({:updated_gallery_images, _, images}, socket) do
     {:noreply,
      socket
@@ -39,7 +33,7 @@ defmodule BanchanWeb.StudioLive.Offerings.Edit do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
+    <Components.StudioLayout id="studio-layout" flash={@flash} studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">Edit Offering</h1>

--- a/lib/banchan_web/live/studio_live/offerings/new.ex
+++ b/lib/banchan_web/live/studio_live/offerings/new.ex
@@ -15,12 +15,6 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
     {:ok, socket |> assign(gallery_images: nil)}
   end
 
-  @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
   def handle_info({:updated_gallery_images, _, images}, socket) do
     {:noreply,
      socket
@@ -30,7 +24,7 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
+    <Components.StudioLayout id="studio-layout" flash={@flash} studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">New Offering</h1>

--- a/lib/banchan_web/live/studio_live/offerings/new.ex
+++ b/lib/banchan_web/live/studio_live/offerings/new.ex
@@ -17,6 +17,7 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -31,12 +32,8 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
     ~F"""
     <Components.StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:shop}
-      uri={@uri}
     >
       <div>
         <div class="p-6 max-w-lg mx-auto">

--- a/lib/banchan_web/live/studio_live/offerings/new.ex
+++ b/lib/banchan_web/live/studio_live/offerings/new.ex
@@ -17,7 +17,7 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -30,11 +30,7 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:shop}
-    >
+    <Components.StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">New Offering</h1>

--- a/lib/banchan_web/live/studio_live/offerings/new.ex
+++ b/lib/banchan_web/live/studio_live/offerings/new.ex
@@ -24,7 +24,7 @@ defmodule BanchanWeb.StudioLive.Offerings.New do
   @impl true
   def render(assigns) do
     ~F"""
-    <Components.StudioLayout id="studio-layout" flash={@flash} studio={@studio} tab={:shop}>
+    <Components.StudioLayout id="studio-layout" flashes={@flash} studio={@studio} tab={:shop}>
       <div>
         <div class="p-6 max-w-lg mx-auto">
           <h1 class="text-3xl">New Offering</h1>

--- a/lib/banchan_web/live/studio_live/payouts.ex
+++ b/lib/banchan_web/live/studio_live/payouts.ex
@@ -186,7 +186,7 @@ defmodule BanchanWeb.StudioLive.Payouts do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:payouts}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} tab={:payouts}>
       <div class="flex flex-col grow max-h-full">
         <div class="flex flex-row grow md:grow-0">
           <div class={"flex flex-col basis-full md:basis-1/4 px-4 sidebar", "hidden md:flex": @payout_id}>

--- a/lib/banchan_web/live/studio_live/payouts.ex
+++ b/lib/banchan_web/live/studio_live/payouts.ex
@@ -17,7 +17,8 @@ defmodule BanchanWeb.StudioLive.Payouts do
 
   @impl true
   def handle_params(params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
+
     if socket.redirected do
       {:noreply, socket}
     else
@@ -188,11 +189,7 @@ defmodule BanchanWeb.StudioLive.Payouts do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:payouts}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} tab={:payouts}>
       <div class="flex flex-col grow max-h-full">
         <div class="flex flex-row grow md:grow-0">
           <div class={"flex flex-col basis-full md:basis-1/4 px-4 sidebar", "hidden md:flex": @payout_id}>

--- a/lib/banchan_web/live/studio_live/payouts.ex
+++ b/lib/banchan_web/live/studio_live/payouts.ex
@@ -16,9 +16,7 @@ defmodule BanchanWeb.StudioLive.Payouts do
   end
 
   @impl true
-  def handle_params(params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-
+  def handle_params(params, _uri, socket) do
     if socket.redirected do
       {:noreply, socket}
     else
@@ -47,7 +45,6 @@ defmodule BanchanWeb.StudioLive.Payouts do
 
       {:noreply,
        socket
-       |> assign(uri: uri)
        |> assign(payout_id: payout_id)
        |> assign(data_pending: true)
        |> assign(fypm_pending: false)
@@ -189,7 +186,7 @@ defmodule BanchanWeb.StudioLive.Payouts do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} tab={:payouts}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:payouts}>
       <div class="flex flex-col grow max-h-full">
         <div class="flex flex-row grow md:grow-0">
           <div class={"flex flex-col basis-full md:basis-1/4 px-4 sidebar", "hidden md:flex": @payout_id}>

--- a/lib/banchan_web/live/studio_live/payouts.ex
+++ b/lib/banchan_web/live/studio_live/payouts.ex
@@ -17,6 +17,7 @@ defmodule BanchanWeb.StudioLive.Payouts do
 
   @impl true
   def handle_params(params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     if socket.redirected do
       {:noreply, socket}
     else
@@ -189,12 +190,8 @@ defmodule BanchanWeb.StudioLive.Payouts do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:payouts}
-      uri={@uri}
     >
       <div class="flex flex-col grow max-h-full">
         <div class="flex flex-row grow md:grow-0">

--- a/lib/banchan_web/live/studio_live/portfolio.ex
+++ b/lib/banchan_web/live/studio_live/portfolio.ex
@@ -47,7 +47,7 @@ defmodule BanchanWeb.StudioLive.Portfolio do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -117,11 +117,7 @@ defmodule BanchanWeb.StudioLive.Portfolio do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:portfolio}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} tab={:portfolio}>
       {#if @current_user_member?}
         <div class="mx-auto py-2">
           <Form for={:portfolio} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/portfolio.ex
+++ b/lib/banchan_web/live/studio_live/portfolio.ex
@@ -47,6 +47,7 @@ defmodule BanchanWeb.StudioLive.Portfolio do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -118,12 +119,8 @@ defmodule BanchanWeb.StudioLive.Portfolio do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:portfolio}
-      uri={@uri}
     >
       {#if @current_user_member?}
         <div class="mx-auto py-2">

--- a/lib/banchan_web/live/studio_live/portfolio.ex
+++ b/lib/banchan_web/live/studio_live/portfolio.ex
@@ -45,12 +45,6 @@ defmodule BanchanWeb.StudioLive.Portfolio do
     {:ok, socket}
   end
 
-  @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
   def handle_info({:updated_gallery_images, _, images}, socket) do
     {:noreply,
      socket
@@ -117,7 +111,7 @@ defmodule BanchanWeb.StudioLive.Portfolio do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} tab={:portfolio}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:portfolio}>
       {#if @current_user_member?}
         <div class="mx-auto py-2">
           <Form for={:portfolio} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/portfolio.ex
+++ b/lib/banchan_web/live/studio_live/portfolio.ex
@@ -111,7 +111,7 @@ defmodule BanchanWeb.StudioLive.Portfolio do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:portfolio}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} tab={:portfolio}>
       {#if @current_user_member?}
         <div class="mx-auto py-2">
           <Form for={:portfolio} change="change" submit="submit">

--- a/lib/banchan_web/live/studio_live/settings.ex
+++ b/lib/banchan_web/live/studio_live/settings.ex
@@ -187,7 +187,7 @@ defmodule BanchanWeb.StudioLive.Settings do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:settings} padding={0}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} tab={:settings} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Notifications</h2>

--- a/lib/banchan_web/live/studio_live/settings.ex
+++ b/lib/banchan_web/live/studio_live/settings.ex
@@ -46,6 +46,7 @@ defmodule BanchanWeb.StudioLive.Settings do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -194,13 +195,9 @@ defmodule BanchanWeb.StudioLive.Settings do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:settings}
       padding={0}
-      uri={@uri}
     >
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">

--- a/lib/banchan_web/live/studio_live/settings.ex
+++ b/lib/banchan_web/live/studio_live/settings.ex
@@ -46,7 +46,7 @@ defmodule BanchanWeb.StudioLive.Settings do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -193,12 +193,7 @@ defmodule BanchanWeb.StudioLive.Settings do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:settings}
-      padding={0}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} tab={:settings} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Notifications</h2>

--- a/lib/banchan_web/live/studio_live/settings.ex
+++ b/lib/banchan_web/live/studio_live/settings.ex
@@ -45,12 +45,6 @@ defmodule BanchanWeb.StudioLive.Settings do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_event("toggle_subscribed", _, socket) do
     if socket.assigns.subscribed? do
       Notifications.unsubscribe_user!(socket.assigns.current_user, socket.assigns.studio)
@@ -193,7 +187,7 @@ defmodule BanchanWeb.StudioLive.Settings do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} tab={:settings} padding={0}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:settings} padding={0}>
       <div class="w-full md:bg-base-300">
         <div class="max-w-xl w-full rounded-xl p-10 mx-auto md:my-10 bg-base-100">
           <h2 class="text-xl py-6">Notifications</h2>

--- a/lib/banchan_web/live/studio_live/shop.ex
+++ b/lib/banchan_web/live/studio_live/shop.ex
@@ -38,7 +38,7 @@ defmodule BanchanWeb.StudioLive.Shop do
 
   @impl true
   def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri)
+    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -159,11 +159,7 @@ defmodule BanchanWeb.StudioLive.Shop do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout
-      id="studio-layout"
-      studio={@studio}
-      tab={:shop}
-    >
+    <StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
       {#if Studios.charges_enabled?(@studio) && is_nil(@studio.disable_info) && is_nil(@studio.deleted_at) &&
           is_nil(@studio.archived_at)}
         <div

--- a/lib/banchan_web/live/studio_live/shop.ex
+++ b/lib/banchan_web/live/studio_live/shop.ex
@@ -153,7 +153,7 @@ defmodule BanchanWeb.StudioLive.Shop do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:shop}>
+    <StudioLayout flashes={@flash} id="studio-layout" studio={@studio} tab={:shop}>
       {#if Studios.charges_enabled?(@studio) && is_nil(@studio.disable_info) && is_nil(@studio.deleted_at) &&
           is_nil(@studio.archived_at)}
         <div

--- a/lib/banchan_web/live/studio_live/shop.ex
+++ b/lib/banchan_web/live/studio_live/shop.ex
@@ -37,12 +37,6 @@ defmodule BanchanWeb.StudioLive.Shop do
   end
 
   @impl true
-  def handle_params(_params, uri, socket) do
-    socket = Context.put(socket, uri: uri, flash: socket.assigns.flash)
-    {:noreply, socket |> assign(uri: uri)}
-  end
-
-  @impl true
   def handle_info(%{event: "charges_state_changed", payload: enabled?}, socket) do
     {:noreply,
      socket
@@ -159,7 +153,7 @@ defmodule BanchanWeb.StudioLive.Shop do
   @impl true
   def render(assigns) do
     ~F"""
-    <StudioLayout id="studio-layout" studio={@studio} tab={:shop}>
+    <StudioLayout flash={@flash} id="studio-layout" studio={@studio} tab={:shop}>
       {#if Studios.charges_enabled?(@studio) && is_nil(@studio.disable_info) && is_nil(@studio.deleted_at) &&
           is_nil(@studio.archived_at)}
         <div

--- a/lib/banchan_web/live/studio_live/shop.ex
+++ b/lib/banchan_web/live/studio_live/shop.ex
@@ -38,6 +38,7 @@ defmodule BanchanWeb.StudioLive.Shop do
 
   @impl true
   def handle_params(_params, uri, socket) do
+    socket = Context.put(socket, uri: uri)
     {:noreply, socket |> assign(uri: uri)}
   end
 
@@ -160,12 +161,8 @@ defmodule BanchanWeb.StudioLive.Shop do
     ~F"""
     <StudioLayout
       id="studio-layout"
-      current_user={@current_user}
-      flashes={@flash}
       studio={@studio}
-      current_user_member?={@current_user_member?}
       tab={:shop}
-      uri={@uri}
     >
       {#if Studios.charges_enabled?(@studio) && is_nil(@studio.disable_info) && is_nil(@studio.deleted_at) &&
           is_nil(@studio.archived_at)}

--- a/lib/banchan_web/live/studio_live/studio_live_helpers.ex
+++ b/lib/banchan_web/live/studio_live/studio_live_helpers.ex
@@ -29,6 +29,12 @@ defmodule BanchanWeb.StudioLive.Helpers do
       |> assign(studio: studio)
       |> assign(current_user_member?: current_user_member?)
 
+    socket =
+      Surface.Components.Context.put(socket,
+        studio: studio,
+        current_user_member?: current_user_member?
+      )
+
     cond do
       current_member && !current_user_member? &&
           (is_nil(socket.assigns.current_user) || !Accounts.mod?(socket.assigns.current_user)) ->

--- a/lib/banchan_web/live/studio_live/studio_live_helpers.ex
+++ b/lib/banchan_web/live/studio_live/studio_live_helpers.ex
@@ -8,6 +8,8 @@ defmodule BanchanWeb.StudioLive.Helpers do
 
   import Ecto.Query
 
+  alias Surface.Components.Context
+
   alias Banchan.Accounts
   alias Banchan.Accounts.User
   alias Banchan.Studios
@@ -30,7 +32,7 @@ defmodule BanchanWeb.StudioLive.Helpers do
       |> assign(current_user_member?: current_user_member?)
 
     socket =
-      Surface.Components.Context.put(socket,
+      Context.put(socket,
         studio: studio,
         current_user_member?: current_user_member?
       )

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -5,6 +5,8 @@ defmodule BanchanWeb.UserLiveAuth do
   import Phoenix.LiveView
   import Phoenix.Component
 
+  alias Surface.Components.Context
+
   alias Banchan.Accounts
   alias Banchan.Accounts.User
 
@@ -19,13 +21,13 @@ defmodule BanchanWeb.UserLiveAuth do
         find_current_user(session)
       end)
 
-    socket = Surface.Components.Context.put(socket, current_user: socket.assigns.current_user)
+    socket = Context.put(socket, current_user: socket.assigns.current_user)
 
     socket =
       socket
       |> detach_hook(:context_uri_hook, :handle_params)
       |> attach_hook(:context_uri_hook, :handle_params, fn _params, uri, socket ->
-        {:cont, socket |> assign(uri: uri) |> Surface.Components.Context.put(uri: uri)}
+        {:cont, socket |> assign(uri: uri) |> Context.put(uri: uri)}
       end)
 
     cond do

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -19,6 +19,8 @@ defmodule BanchanWeb.UserLiveAuth do
         find_current_user(session)
       end)
 
+    socket = Surface.Components.Context.put(socket, current_user: socket.assigns.current_user)
+
     cond do
       auth == :redirect_if_authed && socket.assigns.current_user ->
         {:halt,

--- a/lib/banchan_web/live/user_live_auth.ex
+++ b/lib/banchan_web/live/user_live_auth.ex
@@ -21,6 +21,13 @@ defmodule BanchanWeb.UserLiveAuth do
 
     socket = Surface.Components.Context.put(socket, current_user: socket.assigns.current_user)
 
+    socket =
+      socket
+      |> detach_hook(:context_uri_hook, :handle_params)
+      |> attach_hook(:context_uri_hook, :handle_params, fn _params, uri, socket ->
+        {:cont, socket |> assign(uri: uri) |> Surface.Components.Context.put(uri: uri)}
+      end)
+
     cond do
       auth == :redirect_if_authed && socket.assigns.current_user ->
         {:halt,

--- a/test/banchan_web/components/layout_test.exs
+++ b/test/banchan_web/components/layout_test.exs
@@ -10,7 +10,7 @@ defmodule BanchanWeb.Components.NavTest do
     html =
       render_surface do
         ~F"""
-        <Layout uri="https://example.com" current_user={nil} flashes={%{}} />
+        <Layout flashes={%{}} />
         """
       end
 
@@ -23,7 +23,7 @@ defmodule BanchanWeb.Components.NavTest do
     html =
       render_surface do
         ~F"""
-        <Layout uri="https://example.com" current_user={nil} flashes={%{}} />
+        <Layout flashes={%{}} />
         """
       end
 

--- a/test/banchan_web/components/nav_test.exs
+++ b/test/banchan_web/components/nav_test.exs
@@ -10,7 +10,7 @@ defmodule BanchanWeb.Components.SessionTest do
     html =
       render_surface do
         ~F"""
-        <Nav uri="https://example.com" current_user={nil} />
+        <Nav />
         """
       end
 


### PR DESCRIPTION
some things, like `@current_user`, are set at a very high level, and we've been doing a lot of property drilling with them. This PR puts them into Surface `Context`s, so we can just define them at the specific places they get used.