### PR TITLE
Fix long tag pills

### DIFF
--- a/lib/banchan_web/components/tag.ex
+++ b/lib/banchan_web/components/tag.ex
@@ -22,8 +22,8 @@ defmodule BanchanWeb.Components.Tag do
         {@tag}
       </LiveRedirect>
     {#else}
-      <div class="rounded-full badge badge-outline badge-primary font-semibold uppercase no-underline">
-        {@tag}
+      <div class="rounded-full badge badge-outline badge-primary font-semibold uppercase no-underline max-w-full">
+        <p class="truncate" title={@tag}>{@tag}</p>
       </div>
     {/if}
     """


### PR DESCRIPTION
Fix for #324.

When tag text is too long to fit, truncate it and show ellipses. Also add a `title=` attribute, so you can see the full text on hover.

Note the full text is read by screenreaders, but is not accessible via the keyboard, since the `div`s aren't (and shouldn't be, since they're not links) tab-navigable. I didn't see any way to get the Tailwind pills to wrap across lines, which might be a better solution here. I can try to look into that more, if this is a blocker.

## Screenshots

<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/1382374/209573893-73c9ef59-aa74-40b1-a166-d4342d1aac19.png)
</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/1382374/209573932-65af3950-4707-4151-ac36-b106728be513.png)
</details>

<details><summary>After, on hover</summary>

![image](https://user-images.githubusercontent.com/1382374/209573963-8ae45989-af21-4c18-97fe-ea6b35f5edf5.png)
</details>