### PR TITLE
Account deactivation for OAuth users

### DIFF
--- a/lib/banchan/accounts/accounts.ex
+++ b/lib/banchan/accounts/accounts.ex
@@ -1731,6 +1731,6 @@ defmodule Banchan.Accounts do
   Returns where user is from OAuth registration
   """
   def oauth_user?(%User{} = user) do
-    !!user.discord_uid || !!user.google_uid
+    !is_nil(user.discord_uid) || !is_nil(user.google_uid)
   end
 end

--- a/lib/banchan/accounts/accounts.ex
+++ b/lib/banchan/accounts/accounts.ex
@@ -1660,9 +1660,9 @@ defmodule Banchan.Accounts do
         user
         |> User.deactivate_changeset()
         |> then(fn changeset ->
-          # NB(@zkat): Users without emails are OAuth users. They also
-          # do not have passwords. So we just skip the password check.
-          if user.email && !admin?(actor) do
+          # NB(@serra-allgood): OAuth users do not have meaningful passwords.
+          # So we just skip the password check.
+          if !oauth_user?(user) && !admin?(actor) do
             User.validate_current_password(changeset, password)
           else
             changeset
@@ -1725,5 +1725,12 @@ defmodule Banchan.Accounts do
         end
       end)
     end)
+  end
+
+  @doc """
+  Returns where user is from OAuth registration
+  """
+  def oauth_user?(%User{} = user) do
+    !!user.discord_uid || !!user.google_uid
   end
 end

--- a/lib/banchan/studios/studios.ex
+++ b/lib/banchan/studios/studios.ex
@@ -160,7 +160,11 @@ defmodule Banchan.Studios do
          code: :invalid_request_error,
          message: "Apple Pay is not currently supported in your country" <> country
        }} ->
-        Logger.error("Tried to enable Apple Pay for a country where it isn't supported" <> country <> " Account ID: #{account.id}.")
+        Logger.error(
+          "Tried to enable Apple Pay for a country where it isn't supported" <>
+            country <> " Account ID: #{account.id}."
+        )
+
         :ok
 
       {:error, error} ->

--- a/lib/banchan_web/live/auth_live/settings_live.ex
+++ b/lib/banchan_web/live/auth_live/settings_live.ex
@@ -591,7 +591,7 @@ defmodule BanchanWeb.SettingsLive do
           </p>
           <p class="py-2 font-semibold">Are you sure?</p>
 
-          {#if @current_user.email}
+          {#if !Accounts.oauth_user?(@current_user)}
             <TextInput name={:password} icon="lock" opts={required: true, type: :password} />
           {/if}
           <Submit class="w-full btn-error" label="Confirm" />


### PR DESCRIPTION
This PR addresses issue #503. I'm guessing OAuth users did not originally store their email but that was changed at some point, so in places checking for email presence to determine if a user is from OAuth registration, a false positive was being found.

This PR adds a utility function to the `Accounts` context checking explicitly for `discord_uid` or `google_uid` to determine if a user is an OAuth user and uses it during the `deactivate_user` function and to determine the password input display in `settings_live`.