### PR TITLE
Playing around with summary and options labeling

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -108,6 +108,9 @@ config :surface, :components, [
 
 config :stripity_stripe, api_version: "2020-08-27"
 
+config :money,
+  symbol: false
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/banchan/commissions/commission.ex
+++ b/lib/banchan/commissions/commission.ex
@@ -21,10 +21,10 @@ defmodule Banchan.Commissions.Commission do
       default: :submitted
 
     has_many :line_items, Banchan.Commissions.LineItem,
-      preload_order: [asc: :inserted_at],
+      preload_order: [asc: :inserted_at, asc: :id],
       on_replace: :delete
 
-    has_many :events, Banchan.Commissions.Event, preload_order: [asc: :inserted_at]
+    has_many :events, Banchan.Commissions.Event, preload_order: [asc: :inserted_at, asc: :id]
 
     belongs_to :offering, Banchan.Offerings.Offering
     belongs_to :studio, Banchan.Studios.Studio

--- a/lib/banchan/commissions/commissions.ex
+++ b/lib/banchan/commissions/commissions.ex
@@ -1087,7 +1087,7 @@ defmodule Banchan.Commissions do
                line_items <-
                  commission.line_items
                  |> Enum.filter(fn line_item ->
-                  is_nil(removed) || removed.id != line_item.id
+                   is_nil(removed) || removed.id != line_item.id
                  end)
                  |> Enum.map(fn li ->
                    if li.id == line_item.id do

--- a/lib/banchan/commissions/commissions.ex
+++ b/lib/banchan/commissions/commissions.ex
@@ -456,7 +456,7 @@ defmodule Banchan.Commissions do
           i in Invoice,
           where:
             i.commission_id == ^commission.id and
-              i.status == :succeeded,
+              i.status in [:succeeded, :released],
           select: i.tip
         )
         |> Repo.all()
@@ -499,7 +499,7 @@ defmodule Banchan.Commissions do
       line_items,
       Money.new(0, currency),
       fn item, acc ->
-        Money.add(acc, item.amount)
+        Money.add(acc, Money.multiply(item.amount, item.count || 1))
       end
     )
   end

--- a/lib/banchan/commissions/commissions.ex
+++ b/lib/banchan/commissions/commissions.ex
@@ -1039,7 +1039,7 @@ defmodule Banchan.Commissions do
                %Commission{} = commission <- %{commission | line_items: line_items},
                {:ok, event} <-
                  create_event(:line_item_removed, actor, commission, true, [], %{
-                   amount: line_item.amount,
+                   amount: Money.multiply(line_item.amount, line_item.count),
                    text: line_item.name
                  }) do
             Notifications.commission_line_items_changed(commission, actor)

--- a/lib/banchan/commissions/common.ex
+++ b/lib/banchan/commissions/common.ex
@@ -28,6 +28,8 @@ defmodule Banchan.Commissions.Common do
     :comment,
     :line_item_added,
     :line_item_removed,
+    :line_item_count_increased,
+    :line_item_count_decreased,
     :payment_processed,
     :refund_processed,
     :status,

--- a/lib/banchan/commissions/event.ex
+++ b/lib/banchan/commissions/event.ex
@@ -35,7 +35,7 @@ defmodule Banchan.Commissions.Event do
   def changeset(event, attrs) do
     event
     |> cast(attrs, [:type, :text, :amount, :status])
-    |> validate_money(:amount)
+    |> validate_money(:amount, nil, true)
     |> validate_required([:type])
     |> validate_text()
   end

--- a/lib/banchan/commissions/line_item.ex
+++ b/lib/banchan/commissions/line_item.ex
@@ -12,6 +12,7 @@ defmodule Banchan.Commissions.LineItem do
     field :description, :string
     field :name, :string
     field :sticky, :boolean
+    field :count, :integer, default: 1
 
     belongs_to :commission, Banchan.Commissions.Commission
     belongs_to :option, Banchan.Offerings.OfferingOption, foreign_key: :offering_option_id
@@ -22,9 +23,10 @@ defmodule Banchan.Commissions.LineItem do
   @doc false
   def changeset(line_item, attrs) do
     line_item
-    |> cast(attrs, [:amount, :name, :description, :sticky])
+    |> cast(attrs, [:amount, :name, :description, :sticky, :count])
     |> cast_assoc(:commission)
     |> cast_assoc(:option)
+    |> validate_number(:count, greater_than_or_equal_to: 1)
     |> validate_money(:amount)
     |> validate_required([:amount, :name, :description])
     |> validate_length(:name, max: 50)

--- a/lib/banchan/commissions/line_item.ex
+++ b/lib/banchan/commissions/line_item.ex
@@ -12,6 +12,7 @@ defmodule Banchan.Commissions.LineItem do
     field :description, :string
     field :name, :string
     field :sticky, :boolean
+    field :multiple, :boolean, default: false
     field :count, :integer, default: 1
 
     belongs_to :commission, Banchan.Commissions.Commission
@@ -23,7 +24,7 @@ defmodule Banchan.Commissions.LineItem do
   @doc false
   def changeset(line_item, attrs) do
     line_item
-    |> cast(attrs, [:amount, :name, :description, :sticky, :count])
+    |> cast(attrs, [:amount, :name, :description, :sticky, :count, :multiple])
     |> cast_assoc(:commission)
     |> cast_assoc(:option)
     |> validate_number(:count, greater_than_or_equal_to: 1)
@@ -41,5 +42,13 @@ defmodule Banchan.Commissions.LineItem do
     |> validate_required([:amount, :name, :description])
     |> validate_length(:name, max: 50)
     |> validate_length(:description, max: 160)
+  end
+
+  @doc false
+  def count_changeset(line_item, attrs) do
+    line_item
+    |> cast(attrs, [:count])
+    |> validate_required(:count)
+    |> validate_number(:count, greater_than_or_equal_to: 0)
   end
 end

--- a/lib/banchan/commissions/notifications.ex
+++ b/lib/banchan/commissions/notifications.ex
@@ -228,6 +228,22 @@ defmodule Banchan.Commissions.Notifications do
     "A line item has been removed from this commission:\n\n#{text}: #{Payments.print_money(amount)}"
   end
 
+  defp new_event_notification_body(%Event{
+         type: :line_item_count_increased,
+         amount: amount,
+         text: text
+       }) do
+    "Line item count for #{text}: #{Payments.print_money(amount)}"
+  end
+
+  defp new_event_notification_body(%Event{
+         type: :line_item_count_decreased,
+         amount: amount,
+         text: text
+       }) do
+    "Line item count for #{text}: #{Payments.print_money(amount)}"
+  end
+
   defp new_event_notification_body(%Event{type: :payment_processed, amount: amount}) do
     "A payment for #{Payments.print_money(amount)} has been successfully processed."
   end

--- a/lib/banchan/offerings/offering_option.ex
+++ b/lib/banchan/offerings/offering_option.ex
@@ -14,7 +14,6 @@ defmodule Banchan.Offerings.OfferingOption do
     field :name, :string
     field :price, Money.Ecto.Composite.Type
     field :default, :boolean, default: false
-    field :sticky, :boolean, default: false
     field :multiple, :boolean, default: false
 
     belongs_to :offering, Offering
@@ -25,36 +24,10 @@ defmodule Banchan.Offerings.OfferingOption do
   @doc false
   def changeset(offering_option, attrs) do
     offering_option
-    |> cast(attrs, [:name, :description, :price, :default, :sticky, :multiple])
+    |> cast(attrs, [:name, :description, :price, :default, :multiple])
     |> validate_money(:price)
-    |> validate_sticky_also_default()
     |> validate_required([:name, :description, :price])
     |> validate_length(:name, max: 50)
     |> validate_length(:description, max: 140)
-  end
-
-  defp validate_sticky_also_default(%{params: params} = changeset) when is_map(params) do
-    {:ok, sticky} = Ecto.Type.cast(:boolean, Map.get(params, "sticky", "false"))
-    {:ok, default} = Ecto.Type.cast(:boolean, Map.get(params, "default", "false"))
-
-    errors =
-      case {sticky, default} do
-        {true, false} ->
-          [{:sticky, {"only options marked as default can be sticky", [validation: :sticky]}}]
-
-        _ ->
-          []
-      end
-
-    %{
-      changeset
-      | validations: [{:sticky, {:sticky, []}} | changeset.validations],
-        errors: errors ++ changeset.errors,
-        valid?: changeset.valid? and errors == []
-    }
-  end
-
-  defp validate_sticky_also_default(%{params: nil} = changeset) do
-    changeset
   end
 end

--- a/lib/banchan/payments/invoice.ex
+++ b/lib/banchan/payments/invoice.ex
@@ -72,6 +72,8 @@ defmodule Banchan.Payments.Invoice do
       field(:amount, Money.Ecto.Map.Type)
       field(:name, :string)
       field(:description, :string)
+      field(:multiple, :boolean)
+      field(:count, :integer)
     end
 
     timestamps()
@@ -173,7 +175,7 @@ defmodule Banchan.Payments.Invoice do
 
   defp line_item_changeset(schema, params) do
     schema
-    |> cast(params, [:amount, :name, :description])
+    |> cast(params, [:amount, :name, :description, :multiple, :count])
     |> validate_money(:amount)
     |> validate_required([
       :amount,

--- a/lib/banchan/payments/payments.ex
+++ b/lib/banchan/payments/payments.ex
@@ -353,7 +353,9 @@ defmodule Banchan.Payments do
               "amount" => %{
                 "amount" => &1.amount.amount,
                 "currency" => &1.amount.currency
-              }
+              },
+              "multiple" => &1.multiple,
+              "count" => &1.count
             }
           )
         )

--- a/lib/banchan/payments/payments.ex
+++ b/lib/banchan/payments/payments.ex
@@ -1640,7 +1640,7 @@ defmodule Banchan.Payments do
       "$" -> currency_symbol(money.currency) <> Money.to_string(money, symbol: false)
       "" -> currency_symbol(money.currency) <> " " <> Money.to_string(money, symbol: false)
       " " -> currency_symbol(money.currency) <> " " <> Money.to_string(money, symbol: false)
-      _ -> Money.to_string(money)
+      _ -> Money.to_string(money, symbol: true)
     end
   end
 

--- a/lib/banchan/validators.ex
+++ b/lib/banchan/validators.ex
@@ -30,9 +30,10 @@ defmodule Banchan.Validators do
     |> unique_constraint(field)
   end
 
-  def validate_money(changeset, field, max \\ nil) do
+  def validate_money(changeset, field, max \\ nil, allow_negative \\ false) do
     validate_change(changeset, field, fn
-      _, %Money{amount: amount} when amount >= 0 and (is_nil(max) or amount <= max.amount) ->
+      _, %Money{amount: amount}
+      when (amount >= 0 or allow_negative) and (is_nil(max) or amount <= max.amount) ->
         []
 
       _, %Money{} when not is_nil(max) ->

--- a/lib/banchan_web/components/collapse.ex
+++ b/lib/banchan_web/components/collapse.ex
@@ -34,7 +34,7 @@ defmodule BanchanWeb.Components.Collapse do
           {/if}
         </div>
       {/if}
-      <div class={"p-2", hidden: !@open}>
+      <div class={hidden: !@open}>
         <#slot />
       </div>
     </div>

--- a/lib/banchan_web/components/icon/icon.hooks.js
+++ b/lib/banchan_web/components/icon/icon.hooks.js
@@ -1,13 +1,19 @@
 import {
   createIcons,
+  CheckCircle2,
   ChevronDown,
-  LogIn
+  LogIn,
+  PlusCircle,
+  Trash2
 } from "lucide";
 
 // Add icons we want to enable here, and to the import above.
 const enabledIcons = {
+  CheckCircle2,
   ChevronDown,
-  LogIn
+  LogIn,
+  PlusCircle,
+  Trash2
 };
 
 export const Icon = {

--- a/lib/banchan_web/components/icon/icon.hooks.js
+++ b/lib/banchan_web/components/icon/icon.hooks.js
@@ -3,6 +3,8 @@ import {
   CheckCircle2,
   ChevronDown,
   LogIn,
+  Minus,
+  Plus,
   PlusCircle,
   Trash2
 } from "lucide";
@@ -12,6 +14,8 @@ const enabledIcons = {
   CheckCircle2,
   ChevronDown,
   LogIn,
+  Minus,
+  Plus,
   PlusCircle,
   Trash2
 };

--- a/lib/banchan_web/controllers/email/commissions.ex
+++ b/lib/banchan_web/controllers/email/commissions.ex
@@ -28,9 +28,10 @@ defmodule BanchanWeb.Email.Commissions do
       </tr>
       {#for item <- @invoice.line_items}
         <tr>
-          <td>{item.name}</td>
+          <td>{item.name}{#if item.multiple && item.count > 1}
+              x{item.count}{/if}</td>
           <td>{item.description}</td>
-          <td>{Payments.print_money(item.amount)}</td>
+          <td>{Payments.print_money(Money.multiply(item.amount, item.count))}</td>
         </tr>
       {/for}
       <tr>
@@ -64,7 +65,11 @@ defmodule BanchanWeb.Email.Commissions do
     Line Items:
 
     #{assigns.invoice.line_items |> Enum.map_join("\n", fn item -> """
-      * #{item.name} - #{Payments.print_money(item.amount)}
+      * #{item.name}#{if item.multiple && item.count > 1 do
+        " x#{item.count}"
+      else
+        ""
+      end} - #{Payments.print_money(Money.multiply(item.amount, item.count))}
         #{item.description}
       """ end)}
     Total Invoiced: #{Payments.print_money(estimate)}

--- a/lib/banchan_web/live/commission_live/components/addon_list.ex
+++ b/lib/banchan_web/live/commission_live/components/addon_list.ex
@@ -32,7 +32,7 @@ defmodule BanchanWeb.CommissionLive.Components.AddonList do
     <bc-addon-list>
       <ul class="flex flex-col">
         {#for {option, idx} <- Enum.with_index(@offering.options)}
-          {#if option.multiple || !Enum.any?(@line_items, &(&1.option && &1.option.id == option.id))}
+          {#if !Enum.any?(@line_items, &(&1.option && &1.option.id == option.id))}
             <li class="flex flex-row gap-2 py-2">
               {#if @add_item}
                 <button

--- a/lib/banchan_web/live/commission_live/components/addon_list.ex
+++ b/lib/banchan_web/live/commission_live/components/addon_list.ex
@@ -1,0 +1,96 @@
+defmodule BanchanWeb.CommissionLive.Components.AddonList do
+  @moduledoc """
+  Plain component for displaying a list of addons.
+  """
+  use BanchanWeb, :component
+
+  alias Banchan.Commissions
+  alias Banchan.Offerings
+  alias Banchan.Payments
+
+  alias Surface.Components.Form
+
+  alias BanchanWeb.Components.{Collapse, Icon}
+  alias BanchanWeb.Components.Form.{Submit, TextArea, TextInput}
+
+  prop commission, :struct, from_context: :commission
+
+  prop offering, :struct
+  prop line_items, :list, required: true
+  prop add_item, :event
+  prop custom_changeset, :struct
+  prop id, :string, required: true
+  prop submit_custom, :event
+  prop change_custom, :event
+
+  def set_open_custom(id, open?) do
+    Collapse.set_open(id <> "-custom-collapse", open?)
+  end
+
+  def render(assigns) do
+    ~F"""
+    <bc-addon-list>
+      <ul class="flex flex-col">
+        {#for {option, idx} <- Enum.with_index(@offering.options)}
+          {#if option.multiple || !Enum.any?(@line_items, &(&1.option && &1.option.id == option.id))}
+            <li class="flex flex-row gap-2 py-2">
+              {#if @add_item}
+                <button
+                  type="button"
+                  class="w-8 text-xl opacity-50 hover:text-success"
+                  :on-click={@add_item}
+                  value={idx}
+                >
+                  <Icon name="plus-circle" />
+                </button>
+              {#else}
+                <div class="w-8" />
+              {/if}
+              <div class="grow w-full flex flex-col">
+                <div class="font-medium text-sm">{option.name}</div>
+                <div class="text-xs">{option.description}</div>
+              </div>
+              <div class="p-2 text-sm font-medium">+{Payments.print_money(option.price)}</div>
+            </li>
+          {/if}
+        {/for}
+        {#if @custom_changeset}
+          <li class="py-2 pr-4">
+            <Collapse id={@id <> "-custom-collapse"}>
+              <:header>
+                <div class="flex flex-row gap-2 py-2 items-center">
+                  <Icon name="plus-circle" class="w-8 text-xl hover:text-success opacity-50" />
+                  <div class="grow w-full flex flex-col">
+                    <div class="font-medium text-sm">Custom Option</div>
+                    <div class="text-xs">Add a customized option to the summary.</div>
+                  </div>
+                </div>
+              </:header>
+              <Form
+                class="flex flex-col gap-2"
+                for={@custom_changeset}
+                change={@change_custom}
+                submit={@submit_custom}
+              >
+                <TextInput name={:name} opts={required: true, placeholder: "Some Name"} />
+                <TextArea name={:description} opts={required: true, placeholder: "A custom item just for you!"} />
+                <div class="flex flex-row gap-2 items-center py-2">
+                  <div class="flex flex-basis-1/4">{if is_nil(@offering) do
+                      Money.Currency.symbol(Commissions.commission_currency(@commission))
+                    else
+                      Money.Currency.symbol(Offerings.offering_currency(@offering))
+                    end}</div>
+                  <div class="grow">
+                    <TextInput name={:amount} show_label={false} opts={required: true} />
+                  </div>
+                </div>
+                <Submit class="w-full" changeset={@custom_changeset} />
+              </Form>
+            </Collapse>
+          </li>
+        {/if}
+      </ul>
+    </bc-addon-list>
+    """
+  end
+end

--- a/lib/banchan_web/live/commission_live/components/addon_picker.ex
+++ b/lib/banchan_web/live/commission_live/components/addon_picker.ex
@@ -46,8 +46,7 @@ defmodule BanchanWeb.CommissionLive.Components.AddonPicker do
       end
 
     if !socket.assigns.allow_edits ||
-         (!option.multiple &&
-            Enum.any?(commission.line_items, &(&1.option && &1.option.id == option.id))) do
+         Enum.any?(commission.line_items, &(&1.option && &1.option.id == option.id)) do
       # Deny the change. This shouldn't happen unless there's a bug, or
       # someone is trying to send us Shenanigans data.
       {:noreply, socket}

--- a/lib/banchan_web/live/commission_live/components/addon_picker.ex
+++ b/lib/banchan_web/live/commission_live/components/addon_picker.ex
@@ -1,0 +1,162 @@
+defmodule BanchanWeb.CommissionLive.Components.AddonPicker do
+  @moduledoc """
+  Lets you add new options to a commission, based on what's still available.
+  """
+  use BanchanWeb, :live_component
+
+  alias Banchan.Commissions
+  alias Banchan.Commissions.LineItem
+  alias Banchan.Utils
+
+  alias BanchanWeb.CommissionLive.Components.AddonList
+
+  prop current_user, :struct, from_context: :current_user
+  prop current_user_member?, :boolean, from_context: :current_user_member?
+  prop commission, :struct, from_context: :commission
+
+  prop allow_edits, :boolean, default: false
+  prop allow_custom, :boolean, default: false
+
+  data custom_changeset, :struct
+
+  def update(assigns, socket) do
+    socket = socket |> assign(assigns)
+
+    custom_changeset =
+      if socket.assigns.allow_custom do
+        %LineItem{} |> LineItem.custom_changeset(%{})
+      else
+        nil
+      end
+
+    {:ok, socket |> assign(custom_changeset: custom_changeset)}
+  end
+
+  def handle_event("add_item", %{"value" => idx}, socket) do
+    {idx, ""} = Integer.parse(idx)
+
+    commission = socket.assigns.commission
+
+    option =
+      if commission.offering do
+        {:ok, option} = Enum.fetch(commission.offering.options, idx)
+        option
+      else
+        %{}
+      end
+
+    if !socket.assigns.allow_edits ||
+         (!option.multiple &&
+            Enum.any?(commission.line_items, &(&1.option && &1.option.id == option.id))) do
+      # Deny the change. This shouldn't happen unless there's a bug, or
+      # someone is trying to send us Shenanigans data.
+      {:noreply, socket}
+    else
+      Commissions.add_line_item(
+        socket.assigns.current_user,
+        commission,
+        option,
+        socket.assigns.current_user_member?
+      )
+      |> case do
+        {:ok, {_comm, _events}} ->
+          {:noreply, socket}
+
+        {:error, :blocked} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "You are blocked from further interaction with this studio.")
+           |> push_navigate(
+             to: Routes.commission_path(Endpoint, :show, socket.assigns.commission.public_id)
+           )}
+      end
+    end
+  end
+
+  def handle_event(
+        "change_custom",
+        %{
+          "line_item" => %{
+            "name" => name,
+            "description" => description,
+            "amount" => amount
+          }
+        },
+        socket
+      ) do
+    changeset =
+      %LineItem{}
+      |> LineItem.custom_changeset(%{
+        name: name,
+        description: description,
+        amount: Utils.moneyfy(amount, Commissions.commission_currency(socket.assigns.commission))
+      })
+      |> Map.put(:action, :insert)
+
+    {:noreply, socket |> assign(:custom_changeset, changeset)}
+  end
+
+  def handle_event(
+        "submit_custom",
+        %{
+          "line_item" => %{
+            "name" => name,
+            "description" => description,
+            "amount" => amount
+          }
+        },
+        socket
+      ) do
+    commission = socket.assigns.commission
+
+    if socket.assigns.allow_edits do
+      Commissions.add_line_item(
+        socket.assigns.current_user,
+        commission,
+        %{
+          name: name,
+          description: description,
+          amount: Utils.moneyfy(amount, Commissions.commission_currency(commission))
+        },
+        socket.assigns.current_user_member?
+      )
+      |> case do
+        {:ok, {_commission, _events}} ->
+          AddonList.set_open_custom(socket.assigns.id <> "-custom-collapse", false)
+
+          {:noreply,
+           assign(socket,
+             custom_changeset: %LineItem{} |> LineItem.custom_changeset(%{})
+           )}
+
+        {:error, :blocked} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "You are blocked from further interaction with this studio.")
+           |> push_navigate(
+             to: Routes.commission_path(Endpoint, :show, socket.assigns.commission.public_id)
+           )}
+      end
+    else
+      # Deny the change. This shouldn't happen unless there's a bug, or
+      # someone is trying to send us Shenanigans data.
+      {:noreply, socket}
+    end
+  end
+
+  def render(assigns) do
+    ~F"""
+    <bc-addon-picker>
+      <AddonList
+        id={@id <> "-addon-list"}
+        offering={@commission.offering}
+        line_items={@commission.line_items}
+        custom_changeset={@custom_changeset}
+        add_item="add_item"
+        change_custom="change_custom"
+        submit_custom="submit_custom"
+      />
+    </bc-addon-picker>
+    """
+  end
+end

--- a/lib/banchan_web/live/commission_live/components/balance_box.ex
+++ b/lib/banchan_web/live/commission_live/components/balance_box.ex
@@ -36,7 +36,7 @@ defmodule BanchanWeb.CommissionLive.Components.BalanceBox do
     ~F"""
     <div>
       {#if @deposited}
-        <div class="p-2 flex flex-col gap-2">
+        <div class="flex flex-col gap-2">
           <div class="flex flex-row items-center">
             <div class="font-medium grow">Subtotal:</div>
             <div class="text-sm font-medium">

--- a/lib/banchan_web/live/commission_live/components/invoice_box.ex
+++ b/lib/banchan_web/live/commission_live/components/invoice_box.ex
@@ -265,7 +265,7 @@ defmodule BanchanWeb.CommissionLive.Components.InvoiceBox do
     <div class="flex flex-col invoice-box px-2">
       {!-- # NOTE: Older invoices don't have these fields, so we need to check for them here. --}
       {#if @event.invoice.line_items && @event.invoice.deposited}
-        <Summary line_items={@event.invoice.line_items} show_options={false} />
+        <Summary line_items={@event.invoice.line_items} />
         <BalanceBox
           id={@id <> "-balance-box"}
           line_items={@event.invoice.line_items}

--- a/lib/banchan_web/live/commission_live/components/summary.ex
+++ b/lib/banchan_web/live/commission_live/components/summary.ex
@@ -39,6 +39,7 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
               <span class="isolate inline-flex rounded-md shadow-sm pt-2 w-24">
                 <button
                   type="button"
+                  :if={@allow_edits}
                   :on-click={@decrease_item}
                   value={idx}
                   class="relative inline-flex items-center rounded-l-md px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-200 text-content hover:bg-error hover:opacity-75 hover:text-base-100"
@@ -49,6 +50,7 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
                 <span class="relative inline-flex items-center px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-100">{item.count}</span>
                 <button
                   type="button"
+                  :if={@allow_edits}
                   :on-click={@increase_item}
                   value={idx}
                   class="relative -ml-px inline-flex items-center rounded-r-md px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-200 text-content hover:bg-success hover:opacity-75 hover:text-base-100"
@@ -59,7 +61,7 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
               </span>
             {/if}
           </div>
-          <div class="font-medium text-sm">{Payments.print_money(item.amount)}</div>
+          <div class="font-medium text-sm">{Payments.print_money(Money.multiply(item.amount, item.count || 1))}</div>
         </li>
       {/for}
     </ul>

--- a/lib/banchan_web/live/commission_live/components/summary.ex
+++ b/lib/banchan_web/live/commission_live/components/summary.ex
@@ -4,118 +4,40 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
   """
   use BanchanWeb, :component
 
-  alias Banchan.Commissions
   alias Banchan.Payments
 
-  alias Surface.Components.Form
+  alias BanchanWeb.Components.Icon
 
-  alias BanchanWeb.Components.Collapse
-  alias BanchanWeb.Components.Form.{Submit, TextArea, TextInput}
-
-  prop commission, :struct, from_context: :commission
-  prop line_items, :list, required: true
-  prop allow_edits, :boolean, default: false
-  prop show_options, :boolean, default: true
-  prop offering, :struct
-  prop add_item, :event
-  prop remove_item, :event
-
-  prop custom_changeset, :struct
-  prop custom_collapse_id, :string
-  prop submit_custom, :event
-  prop change_custom, :event
+  prop(commission, :struct, from_context: :commission)
+  prop(line_items, :list, required: true)
+  prop(allow_edits, :boolean, default: false)
+  prop(remove_item, :event)
 
   def render(assigns) do
     ~F"""
-    <div class="flex flex-col">
-      <ul class="flex flex-col">
-        {#for {item, idx} <- Enum.with_index(@line_items)}
-          <li class="flex flex-row p-2 gap-2">
-            {#if @allow_edits && !item.sticky}
-              <button
-                type="button"
-                :on-click={@remove_item}
-                value={idx}
-                class="text-xl w-8 fas fa-times-circle text-error"
-              />
-            {#else}
-              <button
-                type="button"
-                disabled="true"
-                title="This item cannot be removed"
-                class="w-8 place-self-center text-xl fas fa-check"
-              />
-            {/if}
-            <div class="grow w-full flex flex-col">
-              <div class="font-medium text-sm">{item.name}</div>
-              <div class="text-xs">{item.description}</div>
-            </div>
-            <div class="p-2 font-medium text-sm">{Payments.print_money(item.amount)}</div>
-          </li>
-        {/for}
-      </ul>
-      {#if @show_options &&
-          @offering &&
-          Enum.any?(@offering.options, fn option ->
-            option.multiple || !Enum.any?(@line_items, &(&1.option && &1.option.id == option.id))
-          end)}
-        <h5 class="px-2 font-medium">Add-ons:</h5>
-        <ul class="flex flex-col">
-          {#for {option, idx} <- Enum.with_index(@offering.options)}
-            {#if option.multiple || !Enum.any?(@line_items, &(&1.option && &1.option.id == option.id))}
-              <li class="flex flex-row gap-2 p-2">
-                {#if @allow_edits}
-                  <button
-                    type="button"
-                    :on-click={@add_item}
-                    value={idx}
-                    class="w-8 text-xl fas fa-plus-circle text-success"
-                  />
-                {#else}
-                  <div class="w-8" />
-                {/if}
-                <div class="grow w-full flex flex-col">
-                  <div class="font-medium text-sm">{option.name}</div>
-                  <div class="text-xs">{option.description}</div>
-                </div>
-                <div class="p-2 text-sm font-medium">{Payments.print_money(option.price)}</div>
-              </li>
-            {/if}
-          {/for}
-          {#if @custom_changeset}
-            <li class="p-2 pr-4">
-              <Collapse id={@custom_collapse_id}>
-                <:header>
-                  <div class="flex flex-row gap-2">
-                    <i type="button" class="w-8 text-xl fas fa-plus-circle text-success" />
-                    <div class="grow flex flex-col">
-                      <div class="font-medium text-sm">Custom Option</div>
-                      <div class="text-xs">Add a customized option to the summary.</div>
-                    </div>
-                  </div>
-                </:header>
-                <Form
-                  class="flex flex-col gap-2"
-                  for={@custom_changeset}
-                  change={@change_custom}
-                  submit={@submit_custom}
-                >
-                  <TextInput name={:name} opts={required: true, placeholder: "Some Name"} />
-                  <TextArea name={:description} opts={required: true, placeholder: "A custom item just for you!"} />
-                  <div class="flex flex-row gap-2 items-center py-2">
-                    <div class="flex flex-basis-1/4">{Money.Currency.symbol(Commissions.commission_currency(@commission))}</div>
-                    <div class="grow">
-                      <TextInput name={:amount} show_label={false} opts={required: true} />
-                    </div>
-                  </div>
-                  <Submit class="w-full" changeset={@custom_changeset} />
-                </Form>
-              </Collapse>
-            </li>
+    <ul class="flex flex-col">
+      {#for {item, idx} <- @line_items |> Enum.with_index()}
+        <li class="flex flex-row py-2 gap-2">
+          {#if @allow_edits && !item.sticky}
+            <button
+              type="button"
+              class="hover:text-error w-8 text-xl opacity-50"
+              :on-click={@remove_item}
+              value={idx}
+            >
+              <Icon name="trash-2" />
+            </button>
+          {#else}
+            <Icon name="check-circle-2" class="w-8 text-xl opacity-50" />
           {/if}
-        </ul>
-      {/if}
-    </div>
+          <div class="grow w-full flex flex-col">
+            <div class="font-medium text-sm">{item.name}</div>
+            <div class="text-xs">{item.description}</div>
+          </div>
+          <div class="font-medium text-sm">{Payments.print_money(item.amount)}</div>
+        </li>
+      {/for}
+    </ul>
     """
   end
 end

--- a/lib/banchan_web/live/commission_live/components/summary.ex
+++ b/lib/banchan_web/live/commission_live/components/summary.ex
@@ -12,6 +12,8 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
   prop(line_items, :list, required: true)
   prop(allow_edits, :boolean, default: false)
   prop(remove_item, :event)
+  prop(increase_item, :event)
+  prop(decrease_item, :event)
 
   def render(assigns) do
     ~F"""
@@ -33,6 +35,29 @@ defmodule BanchanWeb.CommissionLive.Components.Summary do
           <div class="grow w-full flex flex-col">
             <div class="font-medium text-sm">{item.name}</div>
             <div class="text-xs">{item.description}</div>
+            {#if item.multiple}
+              <span class="isolate inline-flex rounded-md shadow-sm pt-2 w-24">
+                <button
+                  type="button"
+                  :on-click={@decrease_item}
+                  value={idx}
+                  class="relative inline-flex items-center rounded-l-md px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-200 text-content hover:bg-error hover:opacity-75 hover:text-base-100"
+                >
+                  <span class="sr-only">Previous</span>
+                  <Icon name="minus" />
+                </button>
+                <span class="relative inline-flex items-center px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-100">{item.count}</span>
+                <button
+                  type="button"
+                  :on-click={@increase_item}
+                  value={idx}
+                  class="relative -ml-px inline-flex items-center rounded-r-md px-2 py-1 ring-1 ring-inset ring-base-300 focus:z-10 bg-base-200 text-content hover:bg-success hover:opacity-75 hover:text-base-100"
+                >
+                  <span class="sr-only">Next</span>
+                  <Icon name="plus" />
+                </button>
+              </span>
+            {/if}
           </div>
           <div class="font-medium text-sm">{Payments.print_money(item.amount)}</div>
         </li>

--- a/lib/banchan_web/live/commission_live/components/summary_box.ex
+++ b/lib/banchan_web/live/commission_live/components/summary_box.ex
@@ -137,7 +137,9 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryBox do
                    "amount" => %{
                      "amount" => &1.amount.amount,
                      "currency" => &1.amount.currency
-                   }
+                   },
+                   "multiple" => &1.multiple,
+                   "count" => &1.count
                  }
                )
            },
@@ -249,7 +251,9 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryBox do
               "amount" => %{
                 "amount" => &1.amount.amount,
                 "currency" => &1.amount.currency
-              }
+              },
+              "multiple" => &1.multiple,
+              "count" => &1.count
             }
           )
         ),

--- a/lib/banchan_web/live/commission_live/components/summary_box.ex
+++ b/lib/banchan_web/live/commission_live/components/summary_box.ex
@@ -399,7 +399,8 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryBox do
           line_items={@commission.line_items}
           tipped={@final_invoice && @final_invoice.tip}
         />
-        <div class="divider" />
+        <div class="w-full mt-2 border-t-2 border-content opacity-10" />
+        <div class="w-full mb-2 border-t-2 border-content opacity-10" />
         {#if @commission.offering}
           <div class="px-2 font-medium text-sm opacity-50">Add-ons</div>
           <AddonPicker

--- a/lib/banchan_web/live/commission_live/components/summary_editor.ex
+++ b/lib/banchan_web/live/commission_live/components/summary_editor.ex
@@ -44,12 +44,53 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryEditor do
     end
   end
 
+  def handle_event("increase_item", %{"value" => idx}, socket) do
+    update_line_item_count(idx, +1, socket)
+  end
+
+  def handle_event("decrease_item", %{"value" => idx}, socket) do
+    update_line_item_count(idx, -1, socket)
+  end
+
+  defp update_line_item_count(idx, delta, socket) do
+    {idx, ""} = Integer.parse(idx)
+    line_item = Enum.at(socket.assigns.commission.line_items, idx)
+
+    if socket.assigns.allow_edits && line_item && !line_item.sticky do
+      Commissions.update_line_item_count(
+        socket.assigns.current_user,
+        socket.assigns.commission,
+        line_item,
+        delta,
+        socket.assigns.current_user_member?
+      )
+      |> case do
+        {:ok, {_commission, _events}} ->
+          {:noreply, socket}
+
+        {:error, :blocked} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "You are blocked from further interaction with this studio.")
+           |> push_navigate(
+             to: Routes.commission_path(Endpoint, :show, socket.assigns.commission.public_id)
+           )}
+      end
+
+      {:noreply, socket}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def render(assigns) do
     ~F"""
     <Summary
       line_items={@commission.line_items}
       allow_edits={@allow_edits}
       remove_item="remove_item"
+      increase_item="increase_item"
+      decrease_item="decrease_item"
     />
     """
   end

--- a/lib/banchan_web/live/commission_live/components/summary_editor.ex
+++ b/lib/banchan_web/live/commission_live/components/summary_editor.ex
@@ -6,95 +6,14 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryEditor do
   use BanchanWeb, :live_component
 
   alias Banchan.Commissions
-  alias Banchan.Commissions.LineItem
-  alias Banchan.Utils
 
   alias BanchanWeb.CommissionLive.Components.Summary
-  alias BanchanWeb.Components.Collapse
 
   prop commission, :struct, from_context: :commission
   prop current_user, :struct, from_context: :current_user
   prop current_user_member?, :boolean, from_context: :current_user_member?
   prop allow_edits, :boolean, required: true
-  prop show_options, :boolean, default: true
 
-  data custom_changeset, :struct
-  data loaded, :boolean, default: false
-
-  def update(assigns, socket) do
-    current_comm = Map.get(socket.assigns, :commission)
-    new_comm = Map.get(assigns, :commission)
-    socket = socket |> assign(assigns)
-
-    custom_changeset =
-      if socket.assigns.allow_edits do
-        %LineItem{} |> LineItem.custom_changeset(%{})
-      else
-        nil
-      end
-
-    if socket.assigns.loaded do
-      {:ok, socket |> assign(custom_changeset: custom_changeset)}
-    else
-      socket =
-        if current_comm && (!new_comm || current_comm.public_id != new_comm.public_id) do
-          socket |> assign(loaded: false)
-        else
-          socket
-        end
-
-      {:ok,
-       socket
-       |> assign(
-         custom_changeset: custom_changeset,
-         loaded: true
-       )}
-    end
-  end
-
-  @impl true
-  def handle_event("add_item", %{"value" => idx}, socket) do
-    {idx, ""} = Integer.parse(idx)
-
-    commission = socket.assigns.commission
-
-    option =
-      if commission.offering do
-        {:ok, option} = Enum.fetch(commission.offering.options, idx)
-        option
-      else
-        %{}
-      end
-
-    if !socket.assigns.allow_edits ||
-         (!option.multiple &&
-            Enum.any?(commission.line_items, &(&1.option && &1.option.id == option.id))) do
-      # Deny the change. This shouldn't happen unless there's a bug, or
-      # someone is trying to send us Shenanigans data.
-      {:noreply, socket}
-    else
-      Commissions.add_line_item(
-        socket.assigns.current_user,
-        commission,
-        option,
-        socket.assigns.current_user_member?
-      )
-      |> case do
-        {:ok, {_comm, _events}} ->
-          {:noreply, socket}
-
-        {:error, :blocked} ->
-          {:noreply,
-           socket
-           |> put_flash(:error, "You are blocked from further interaction with this studio.")
-           |> push_navigate(
-             to: Routes.commission_path(Endpoint, :show, socket.assigns.commission.public_id)
-           )}
-      end
-    end
-  end
-
-  @impl true
   def handle_event("remove_item", %{"value" => idx}, socket) do
     {idx, ""} = Integer.parse(idx)
     line_item = Enum.at(socket.assigns.commission.line_items, idx)
@@ -125,93 +44,12 @@ defmodule BanchanWeb.CommissionLive.Components.SummaryEditor do
     end
   end
 
-  @impl true
-  def handle_event(
-        "change_custom",
-        %{
-          "line_item" => %{
-            "name" => name,
-            "description" => description,
-            "amount" => amount
-          }
-        },
-        socket
-      ) do
-    changeset =
-      %LineItem{}
-      |> LineItem.custom_changeset(%{
-        name: name,
-        description: description,
-        amount: Utils.moneyfy(amount, Commissions.commission_currency(socket.assigns.commission))
-      })
-      |> Map.put(:action, :insert)
-
-    {:noreply, socket |> assign(:custom_changeset, changeset)}
-  end
-
-  @impl true
-  def handle_event(
-        "submit_custom",
-        %{
-          "line_item" => %{
-            "name" => name,
-            "description" => description,
-            "amount" => amount
-          }
-        },
-        socket
-      ) do
-    commission = socket.assigns.commission
-
-    if socket.assigns.allow_edits do
-      Commissions.add_line_item(
-        socket.assigns.current_user,
-        commission,
-        %{
-          name: name,
-          description: description,
-          amount:
-            Utils.moneyfy(amount, Commissions.commission_currency(socket.assigns.commission))
-        },
-        socket.assigns.current_user_member?
-      )
-      |> case do
-        {:ok, {_commission, _events}} ->
-          Collapse.set_open(socket.assigns.id <> "_custom_collapse", false)
-
-          {:noreply,
-           assign(socket,
-             custom_changeset: %LineItem{} |> LineItem.custom_changeset(%{})
-           )}
-
-        {:error, :blocked} ->
-          {:noreply,
-           socket
-           |> put_flash(:error, "You are blocked from further interaction with this studio.")
-           |> push_navigate(
-             to: Routes.commission_path(Endpoint, :show, socket.assigns.commission.public_id)
-           )}
-      end
-    else
-      # Deny the change. This shouldn't happen unless there's a bug, or
-      # someone is trying to send us Shenanigans data.
-      {:noreply, socket}
-    end
-  end
-
   def render(assigns) do
     ~F"""
     <Summary
       line_items={@commission.line_items}
-      offering={@commission.offering}
       allow_edits={@allow_edits}
-      show_options={@show_options}
-      add_item="add_item"
       remove_item="remove_item"
-      custom_changeset={@custom_changeset}
-      custom_collapse_id={@id <> "_custom_collapse"}
-      change_custom="change_custom"
-      submit_custom="submit_custom"
     />
     """
   end

--- a/lib/banchan_web/live/commission_live/components/timeline.ex
+++ b/lib/banchan_web/live/commission_live/components/timeline.ex
@@ -25,10 +25,8 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
 
   def render(assigns) do
     event_chunks =
-      Enum.chunk_by(
-        assigns.commission.events,
-        &(&1.type == :comment)
-      )
+      assigns.commission.events
+      |> Enum.chunk_by(&(&1.type == :comment))
 
     ~F"""
     <div class="snap-y">

--- a/lib/banchan_web/live/commission_live/components/timeline.ex
+++ b/lib/banchan_web/live/commission_live/components/timeline.ex
@@ -57,6 +57,14 @@ defmodule BanchanWeb.CommissionLive.Components.Timeline do
                   <TimelineItem icon="✖" actor={Map.get(@users, event.actor_id)} event={event}>
                     removed <strong>{event.text}</strong> ({Payments.print_money(Money.multiply(event.amount, -1))})
                   </TimelineItem>
+                {#match :line_item_count_increased}
+                  <TimelineItem icon="➕" actor={Map.get(@users, event.actor_id)} event={event}>
+                    line item count for {event.text} ({Payments.print_money(event.amount)})
+                  </TimelineItem>
+                {#match :line_item_count_decreased}
+                  <TimelineItem icon="➖" actor={Map.get(@users, event.actor_id)} event={event}>
+                    line item count for {event.text} ({Payments.print_money(event.amount)})
+                  </TimelineItem>
                 {#match :payment_processed}
                   <TimelineItem
                     icon={Money.Currency.symbol(event.amount)}

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -377,7 +377,10 @@ defmodule BanchanWeb.OfferingLive.Request do
               <div class="divider" />
               <BalanceBox id="balance-box" line_items={@line_items} />
               {#if Enum.any?(@offering.options, &(!&1.default))}
-                <div class="divider" />
+                <div class="flex flex-col gap-2">
+                  <div class="w-full mt-2 border-t-2 border-content opacity-10" />
+                  <div class="w-full mb-2 border-t-2 border-content opacity-10" />
+                </div>
                 <div class="px-2 font-medium text-sm opacity-50">Add-ons</div>
                 <AddonList id="addon-list" offering={@offering} line_items={@line_items} add_item="add_item" />
               {/if}

--- a/lib/banchan_web/live/offering_live/request.ex
+++ b/lib/banchan_web/live/offering_live/request.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.OfferingLive.Request do
 
   import BanchanWeb.StudioLive.Helpers
 
-  alias BanchanWeb.CommissionLive.Components.{BalanceBox, OfferingBox, Summary}
+  alias BanchanWeb.CommissionLive.Components.{AddonList, BalanceBox, OfferingBox, Summary}
   alias BanchanWeb.Components.Form.{Checkbox, QuillInput, Submit, TextInput, UploadInput}
   alias BanchanWeb.Components.{Layout, Markdown}
   alias BanchanWeb.Endpoint
@@ -56,7 +56,7 @@ defmodule BanchanWeb.OfferingLive.Request do
               amount: option.price,
               name: option.name,
               description: option.description,
-              sticky: option.sticky
+              sticky: option.default
             }
           end)
 
@@ -334,19 +334,18 @@ defmodule BanchanWeb.OfferingLive.Request do
       <div class="flex flex-col space-y-2 md:container md:mx-auto p-2">
         <Form for={@changeset} change="change" submit="submit">
           <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div class="flex flex-col md:order-2">
+            <div class="flex flex-col md:order-2 rounded-lg bg-base-200 p-4 shadow-lg">
               <OfferingBox offering={@offering} class="rounded-box hover:bg-base-200 p-2 transition-all" />
               <div class="divider" />
-              <Summary
-                add_item="add_item"
-                allow_edits
-                remove_item="remove_item"
-                line_items={@line_items}
-                offering={@offering}
-              />
-              <div class="pt-6">
-                <BalanceBox id="balance-box" line_items={@line_items} />
-              </div>
+              <div class="font-medium text-sm opacity-50">Cart</div>
+              <Summary allow_edits remove_item="remove_item" line_items={@line_items} />
+              <div class="divider" />
+              <BalanceBox id="balance-box" line_items={@line_items} />
+              {#if Enum.any?(@offering.options, &(!&1.default))}
+                <div class="divider" />
+                <div class="px-2 font-medium text-sm opacity-50">Add-ons</div>
+                <AddonList id="addon-list" offering={@offering} line_items={@line_items} add_item="add_item" />
+              {/if}
             </div>
             <div class="divider md:hidden" />
             <div class="flex flex-col md:col-span-2 md:order-1 gap-4">

--- a/lib/banchan_web/live/offering_live/show.ex
+++ b/lib/banchan_web/live/offering_live/show.ex
@@ -13,7 +13,7 @@ defmodule BanchanWeb.OfferingLive.Show do
 
   alias Surface.Components.LiveRedirect
 
-  alias BanchanWeb.CommissionLive.Components.Summary
+  alias BanchanWeb.CommissionLive.Components.{AddonList, Summary}
 
   alias BanchanWeb.Components.{
     Button,
@@ -59,7 +59,7 @@ defmodule BanchanWeb.OfferingLive.Show do
           amount: option.price,
           name: option.name,
           description: option.description,
-          sticky: option.sticky
+          sticky: option.default
         }
       end)
 
@@ -235,47 +235,58 @@ defmodule BanchanWeb.OfferingLive.Show do
             {/if}
           </div>
           <div class="divider" />
-          <Summary line_items={@line_items} offering={@offering} />
-          {#if !Enum.empty?(@offering.tags)}
-            <h3 class="pt-2 text-lg">Tags</h3>
-            <div class="flex flex-row flex-wrap gap-1">
-              {#for tag <- @offering.tags}
-                <Tag tag={tag} />
-              {/for}
-            </div>
-            <div class="divider" />
-          {/if}
-          <div class="flex flex-row justify-end gap-2">
-            {#if @current_user}
-              <div class="dropdown">
-                <label tabindex="0" class="btn btn-circle btn-outline btn-sm my-2 py-0 grow-0">
-                  <i class="fas fa-ellipsis-vertical" />
-                </label>
-                <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box">
-                  {#if @current_user && (@current_user_member? || Accounts.mod?(@current_user))}
-                    <li>
-                      <LiveRedirect to={Routes.studio_offerings_edit_path(Endpoint, :edit, @offering.studio.handle, @offering.type)}><i class="fas fa-edit" /> Edit</LiveRedirect>
-                    </li>
-                  {/if}
-                  <li>
-                    <button type="button" :on-click="report">
-                      <i class="fas fa-flag" /> Report
-                    </button>
-                  </li>
-                </ul>
+          <div class="rounded-lg bg-base-200 p-4 shadow-lg flex flex-col">
+            {#if Enum.any?(@offering.options, & &1.default)}
+              <div class="px-2 font-medium text-sm opacity-50">Included</div>
+              <Summary line_items={@line_items} />
+              <div class="divider" />
+            {/if}
+            {#if Enum.any?(@offering.options, &(!&1.default))}
+              <div class="px-2 font-medium text-sm opacity-50">Add-ons</div>
+              <AddonList id="addon-list" offering={@offering} line_items={@line_items} />
+              <div class="divider" />
+            {/if}
+            {#if !Enum.empty?(@offering.tags)}
+              <h3 class="pt-2 text-lg">Tags</h3>
+              <div class="flex flex-row flex-wrap gap-1">
+                {#for tag <- @offering.tags}
+                  <Tag tag={tag} />
+                {/for}
               </div>
+              <div class="divider" />
             {/if}
-            {#if @offering.open}
-              <LiveRedirect
-                to={Routes.offering_request_path(Endpoint, :new, @offering.studio.handle, @offering.type)}
-                class="btn text-center btn-primary grow"
-              >Request</LiveRedirect>
-            {#elseif !@offering.user_subscribed?}
-              <Button class="btn-info grow" click="notify_me">Notify Me</Button>
-            {/if}
-            {#if @offering.user_subscribed?}
-              <Button class="btn-info grow" click="unnotify_me">Unsubscribe</Button>
-            {/if}
+            <div class="pt-4 flex flex-row justify-end gap-2">
+              {#if @current_user}
+                <div class="dropdown">
+                  <label tabindex="0" class="btn btn-circle btn-outline btn-sm my-2 py-0 grow-0">
+                    <i class="fas fa-ellipsis-vertical" />
+                  </label>
+                  <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-200 rounded-box">
+                    {#if @current_user && (@current_user_member? || Accounts.mod?(@current_user))}
+                      <li>
+                        <LiveRedirect to={Routes.studio_offerings_edit_path(Endpoint, :edit, @offering.studio.handle, @offering.type)}><i class="fas fa-edit" /> Edit</LiveRedirect>
+                      </li>
+                    {/if}
+                    <li>
+                      <button type="button" :on-click="report">
+                        <i class="fas fa-flag" /> Report
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              {/if}
+              {#if @offering.open}
+                <LiveRedirect
+                  to={Routes.offering_request_path(Endpoint, :new, @offering.studio.handle, @offering.type)}
+                  class="btn text-center btn-primary grow"
+                >Request</LiveRedirect>
+              {#elseif !@offering.user_subscribed?}
+                <Button class="btn-info grow" click="notify_me">Notify Me</Button>
+              {/if}
+              {#if @offering.user_subscribed?}
+                <Button class="btn-info grow" click="unnotify_me">Unsubscribe</Button>
+              {/if}
+            </div>
           </div>
           {#if !Enum.empty?(@related)}
             <div class="hidden md:flex md:flex-col">

--- a/lib/banchan_web/live/studio_live/components/offering.ex
+++ b/lib/banchan_web/live/studio_live/components/offering.ex
@@ -76,8 +76,7 @@ defmodule BanchanWeb.StudioLive.Components.Offering do
                       name: "Default Option 1",
                       description: "Base commission.",
                       price: Money.new(0, socket.assigns.studio.default_currency),
-                      default: true,
-                      sticky: true
+                      default: true
                     }
                   ]
                 },
@@ -570,22 +569,15 @@ defmodule BanchanWeb.StudioLive.Components.Offering do
                   </div>
                 </div>
                 <Checkbox
+                  name={:default}
+                  info="Whether this option is always included as part of the commission."
+                  label="Always Included"
+                />
+                <Checkbox
                   name={:multiple}
                   info="Allow multiple instances of this option at the same time."
                   label="Allow Multiple"
                 />
-                <Checkbox
-                  name={:default}
-                  info="Whether this option is added by default. Default options are also used to calculate your offering's base price."
-                  label="Default"
-                />
-                {#if Ecto.Changeset.fetch_field!(@changeset, :options) |> Enum.at(0) |> then(& &1.default)}
-                  <Checkbox
-                    name={:sticky}
-                    info="Sticky defaults can't be removed from the cart."
-                    label="Sticky Default"
-                  />
-                {/if}
                 <Button class="w-full btn-sm btn-error" value={index} click="remove_option">Remove</Button>
               </Collapse>
             </li>

--- a/priv/repo/migrations/20230720214123_add_count_to_line_items.exs
+++ b/priv/repo/migrations/20230720214123_add_count_to_line_items.exs
@@ -1,0 +1,25 @@
+defmodule Banchan.Repo.Migrations.AddCountToLineItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:line_items) do
+      add(:count, :integer, default: 1)
+    end
+
+    execute(fn ->
+      repo().query!(
+        """
+        UPDATE line_items
+        SET count = 1
+        WHERE count IS NULL;
+        """,
+        [],
+        log: false
+      )
+    end, fn -> :ok end)
+
+    alter table(:line_items) do
+      modify(:count, :integer, default: 1, null: false, from: {:integer, null: true, default: 1})
+    end
+  end
+end

--- a/priv/repo/migrations/20230720214123_add_count_to_line_items.exs
+++ b/priv/repo/migrations/20230720214123_add_count_to_line_items.exs
@@ -3,23 +3,62 @@ defmodule Banchan.Repo.Migrations.AddCountToLineItems do
 
   def change do
     alter table(:line_items) do
-      add(:count, :integer, default: 1)
+      add(:count, :integer, default: 1, null: false)
+      add(:multiple, :boolean)
     end
 
-    execute(fn ->
-      repo().query!(
-        """
-        UPDATE line_items
-        SET count = 1
-        WHERE count IS NULL;
-        """,
-        [],
-        log: false
-      )
-    end, fn -> :ok end)
+    execute(
+      fn ->
+        repo().query!(
+          """
+          UPDATE line_items
+          SET count = 1
+          WHERE count IS NULL;
+          """,
+          [],
+          log: false
+        )
+      end,
+      fn -> :ok end
+    )
+
+    execute(
+      fn ->
+        repo().query!(
+          """
+          UPDATE line_items
+          SET multiple = COALESCE(subq.multiple, false)
+          FROM (SELECT opt.* FROM offering_options AS opt) AS subq
+          WHERE line_items.multiple IS NULL AND subq.id = line_items.offering_option_id;
+          """,
+          [],
+          log: false
+        )
+      end,
+      fn -> :ok end
+    )
+
+    execute(
+      fn ->
+        repo().query!(
+          """
+          UPDATE line_items
+          SET multiple = false
+          WHERE multiple IS NULL;
+          """,
+          [],
+          log: false
+        )
+      end,
+      fn -> :ok end
+    )
 
     alter table(:line_items) do
-      modify(:count, :integer, default: 1, null: false, from: {:integer, null: true, default: 1})
+      modify(:multiple, :boolean,
+        default: false,
+        null: false,
+        from: {:boolean, null: true, default: false}
+      )
     end
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -67,8 +67,7 @@ if Application.fetch_env!(:banchan, :env) == :dev do
             name: "Base Price",
             description: "The commission itself.",
             price: Money.new(10000, :USD),
-            default: true,
-            sticky: true
+            default: true
           },
           %{
             name: "Extra Character",
@@ -104,8 +103,7 @@ if Application.fetch_env!(:banchan, :env) == :dev do
             name: "Base Price",
             description: "One chibi character, to order.",
             price: Money.new(5000, :USD),
-            default: true,
-            sticky: true
+            default: true
           },
           %{
             name: "Extra Character",
@@ -149,8 +147,7 @@ if Application.fetch_env!(:banchan, :env) == :dev do
             name: "Base Price",
             description: "The commission itself.",
             price: Money.new(10000, :USD),
-            default: true,
-            sticky: true
+            default: true
           },
           %{
             name: "Extra Character",


### PR DESCRIPTION
Made a bunch of smaller modifications, so things look like this now:

![Image](https://github.com/BanchanArt/banchan/assets/17535/cfed0b4b-65a0-4da8-8da2-edbb34ede764)

But there's some further changes to make this feel nice:

* [x] Move the "menu" to be below the BalanceBox and retitle it "Add-ons"
* [x] Use a numerical input box for multiples, instead of adding them multiple times.
* [x] Fix alignment of "Custom Option"
* [x] double bar under "total"

mockup (h/t @rjt-rockx):
![image](https://github.com/BanchanArt/banchan/assets/17535/da4abc6e-1eb2-400a-a25f-8c9dc20e13d9)

See also https://tailwindui.com/components/ecommerce/page-examples/shopping-cart-pages#component-a1e2ea92ae3a4e4e74881fbc695f92bf for some help with design
