### PR TITLE
Match elixir in devcontainer to root

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Update the VARIANT arg in docker-compose.yml to pick an Elixir version: 1.9, 1.10, 1.10.4
-ARG VARIANT="1.13.2"
+ARG VARIANT="1.14.5"
 FROM elixir:${VARIANT}
 
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Elixir Version: 
-        VARIANT: "1.13.2"
+        VARIANT: "1.14.5"
         # Phoenix Version: 
         PHOENIX_VERSION: "1.6.9"
         # Node Version: 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # Elixir Version: 
         VARIANT: "1.14.5"
         # Phoenix Version: 
-        PHOENIX_VERSION: "1.6.9"
+        PHOENIX_VERSION: "1.7.6"
         # Node Version: 
         NODE_VERSION: "16.15.0"
 


### PR DESCRIPTION
Needed to update the elixir versions in the dev container to match the one in the root `Dockerfile`, in order to get the project to build successfully.