### PR TITLE
Fix iOS overflow when focusing inputs

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -58,22 +58,42 @@ $fa-font-path: "../node_modules/@fortawesome/fontawesome-free/webfonts/";
 .stack-custom {
   @apply inline-grid place-items-end items-end;
 
-  &>* {
+  & > * {
     @apply col-start-1 row-start-1;
   }
 
-  &>* {
+  & > * {
     z-index: 1;
     transform: translateY(5%);
   }
 
-  &>*:nth-child(2) {
+  & > *:nth-child(2) {
     z-index: 2;
     transform: translateY(0%);
   }
 
-  &>*:nth-child(1) {
+  & > *:nth-child(1) {
     z-index: 3;
     transform: translateY(0);
   }
+}
+
+@supports (height: 100dvh) {
+  .h-screen {
+    height: 100dvh;
+  }
+}
+
+@supports (max-height: 100dvh) {
+  .max-h-screen {
+    height: 100dvh;
+  }
+}
+
+.drawer-toggle ~ .drawer-side {
+  max-height: 100dvh;
+}
+
+body {
+  min-height: -webkit-fill-available;
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -88,10 +88,10 @@ $fa-font-path: "../node_modules/@fortawesome/fontawesome-free/webfonts/";
   .max-h-screen {
     height: 100dvh;
   }
-}
 
-.drawer-toggle ~ .drawer-side {
-  max-height: 100dvh;
+  .drawer-toggle ~ .drawer-side {
+    max-height: 100dvh;
+  }
 }
 
 body {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -86,7 +86,7 @@ $fa-font-path: "../node_modules/@fortawesome/fontawesome-free/webfonts/";
 
 @supports (max-height: 100dvh) {
   .max-h-screen {
-    height: 100dvh;
+    max-height: 100dvh;
   }
 
   .drawer-toggle ~ .drawer-side {

--- a/lib/banchan_web/components/layouts/root.sface
+++ b/lib/banchan_web/components/layouts/root.sface
@@ -78,22 +78,8 @@
           };
       </script>
     {/if}
-    <style>
-      body {
-      min-height: 100vh;
-      min-height: -webkit-fill-available;
-      }
-      @supports(min-height: 100dvh) {
-      body {
-      min-height: 100dvh;
-      }
-      }
-      html {
-      min-height: -webkit-fill-available;
-      }
-    </style>
   </head>
-  <body class="overflow-hidden bg-base-200">
+  <body class="fixed top-0 bottom-0 left-0 right-0 overflow-hidden bg-base-200">
     {@inner_content}
   </body>
 </html>


### PR DESCRIPTION
Using the fixed class seems to avoid the empty space behavior on the simulator, needs to be tested on real devices yet