### PR TITLE
fix how we pull in pfps when creating oauth users

### DIFF
--- a/lib/banchan/validators.ex
+++ b/lib/banchan/validators.ex
@@ -146,7 +146,7 @@ defmodule Banchan.Validators do
     |> validate_format(:furaffinity_handle, ~r/^[a-zA-Z0-9_-]+$/,
       message: "must be a valid Furaffinity handle."
     )
-    |> validate_format(:discord_handle, ~r/^[a-zA-Z0-9_-]+(#\d{4})?$/,
+    |> validate_format(:discord_handle, ~r/^[a-zA-Z0-9_.-]+(#\d{4})?$/,
       message: "must be a valid Discord handle."
     )
     |> validate_format(:artstation_handle, ~r/^[a-zA-Z0-9_]+$/,


### PR DESCRIPTION
When the oauth service did not include a file extension in its url, which is a totally reasonable thing to do, we would just... fail to create the user altogether.

This PR does two things:

1. Makes sure user creation happens regardless of pfp processing.
2. Uses `Image` to load the raw binary data for the oauth pfp and always write it out as jpg.